### PR TITLE
Dossier API extension

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -604,6 +604,8 @@ function zw_rest_api_init()
                         $output[] = [
                             'type' => 'dossier',
                             'title' => $title,
+                            'count' => $block['aantal_artikelen'],
+                            'offset' => $block['offset'],
                             'term_id' => $term->term_id,
                         ];
                         break;

--- a/page-front-page.php
+++ b/page-front-page.php
@@ -142,7 +142,8 @@ foreach ($context['options']['desking_blokken_voorpagina'] as &$block) {
             $block['term'] = Timber::get_term($block['selecteer_dossier'], 'dossier');
             $block['posts'] = Timber::get_posts(
                 [
-                    'posts_per_page' => 4,
+	                'posts_per_page' => $block['aantal_artikelen'],
+	                'offset' => $block['offset'],
                     'post_type' => 'post',
                     'ignore_sticky_posts' => true,
                     'tax_query' => [

--- a/page-front-page.php
+++ b/page-front-page.php
@@ -142,8 +142,8 @@ foreach ($context['options']['desking_blokken_voorpagina'] as &$block) {
             $block['term'] = Timber::get_term($block['selecteer_dossier'], 'dossier');
             $block['posts'] = Timber::get_posts(
                 [
-	                'posts_per_page' => $block['aantal_artikelen'],
-	                'offset' => $block['offset'],
+                    'posts_per_page' => $block['aantal_artikelen'],
+                    'offset' => $block['offset'],
                     'post_type' => 'post',
                     'ignore_sticky_posts' => true,
                     'tax_query' => [

--- a/streekomroep-acf-json/group_5ffaff39b59a5.json
+++ b/streekomroep-acf-json/group_5ffaff39b59a5.json
@@ -63,13 +63,13 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "default_value": "",
+                            "default_value": 6,
                             "placeholder": "",
                             "prepend": "",
                             "append": "",
-                            "min": "",
+                            "min": 0,
                             "max": "",
-                            "step": ""
+                            "step": 1
                         },
                         {
                             "key": "field_5ffb004a390b8",
@@ -88,9 +88,9 @@
                             "placeholder": "",
                             "prepend": "",
                             "append": "",
-                            "min": "",
+                            "min": 0,
                             "max": "",
-                            "step": ""
+                            "step": 1
                         }
                     ],
                     "min": "",
@@ -350,11 +350,11 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "default_value": "",
+                            "default_value": 4,
                             "placeholder": "",
                             "prepend": "",
                             "append": "",
-                            "min": "",
+                            "min": 0,
                             "max": "",
                             "step": ""
                         },
@@ -371,11 +371,11 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "default_value": "",
+                            "default_value": 0,
                             "placeholder": "",
                             "prepend": "",
                             "append": "",
-                            "min": "",
+                            "min": 0,
                             "max": "",
                             "step": ""
                         }
@@ -407,5 +407,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1647528450
+    "modified": 1647772742
 }

--- a/style.css
+++ b/style.css
@@ -2,5 +2,5 @@
  * Theme Name: Streekomroep
  * Description: This is a WordPress theme made for Streekomroep ZuidWest in The Netherlands. It's made using Timber and Tailwind CSS and provides functionality for regional news, radio and tv broadcasts.
  * Author: Upstatement & Streekomroep ZuidWest
- * Version: 1.4
+ * Version: 1.4.1
 */


### PR DESCRIPTION
Adds fields to select the amount of articles and offset for the single dossier block. Integrate the new logic into frontpage post query and show them in the desking API too.