### PR TITLE
🐰

### DIFF
--- a/lib/post_type_fragment.php
+++ b/lib/post_type_fragment.php
@@ -19,7 +19,7 @@
 		'label'                 => 'Fragment',
 		'description'           => 'Nieuwsfragmenten',
 		'labels'                => $labels,
-		'supports'              => array( 'title', 'editor', 'thumbnail', 'comments', 'revisions', 'custom-fields', 'excerpt' ),
+		'supports'              => array( 'title', 'author', 'editor', 'thumbnail', 'comments', 'revisions', 'custom-fields', 'excerpt' ),
 		'taxonomies'            => array( 'category', 'post_tag', 'regio', 'dossier' ),
 		'hierarchical'          => false,
 		'public'                => true,

--- a/streekomroep-acf-json/group_5f75031ebb507.json
+++ b/streekomroep-acf-json/group_5f75031ebb507.json
@@ -49,19 +49,57 @@
         },
         {
             "key": "field_5f7503a2f4e72",
-            "label": "URL",
-            "name": "fragment_url",
-            "type": "oembed",
-            "instructions": "Volledige link naar de Vimeo-video of .mp3 audio file",
+            "label": "Video",
+            "name": "fragment_video",
+            "type": "text",
+            "instructions": "Het video ID op Bunny CDN.",
             "required": 0,
-            "conditional_logic": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5f75032710141",
+                        "operator": "==",
+                        "value": "Video"
+                    }
+                ]
+            ],
             "wrapper": {
                 "width": "",
                 "class": "",
                 "id": ""
             },
-            "width": "",
-            "height": ""
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_624088a91a622",
+            "label": "Audio",
+            "name": "fragment_audio",
+            "type": "file",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5f75032710141",
+                        "operator": "==",
+                        "value": "Audio"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "array",
+            "library": "all",
+            "min_size": "",
+            "max_size": "",
+            "mime_types": ""
         }
     ],
     "location": [
@@ -81,5 +119,6 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1609612575
+    "show_in_rest": 0,
+    "modified": 1648396679
 }

--- a/streekomroep-acf-json/group_5fba8f2f25001.json
+++ b/streekomroep-acf-json/group_5fba8f2f25001.json
@@ -26,7 +26,7 @@
             "label": "Gemist locatie",
             "name": "tv_show_gemist_locatie",
             "type": "number",
-            "instructions": "Vul het ID van de Vimeo-map waar de uitzendingen in staan in.",
+            "instructions": "Vul het ID van de Bunny CDN Collection waar de uitzendingen in staan in.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -88,5 +88,6 @@
     ],
     "active": true,
     "description": "",
-    "modified": 1615303633
+    "show_in_rest": 0,
+    "modified": 1648394597
 }

--- a/streekomroep-acf-json/group_5fba8f2f25001.json
+++ b/streekomroep-acf-json/group_5fba8f2f25001.json
@@ -7,7 +7,7 @@
             "label": "Actief",
             "name": "tv_show_actief",
             "type": "true_false",
-            "instructions": "Indien actief: wordt in overzicht met programma's getoond. Indien niet actief: gearchiveerd programma.",
+            "instructions": "Indien actief: wordt in overzicht met programma's getoond. Indien niet actief: gearchiveerd programma. Wordt niet in overzichten getoond.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -89,5 +89,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1648394597
+    "modified": 1648402004
 }

--- a/streekomroep-acf-json/group_5fba9092307df.json
+++ b/streekomroep-acf-json/group_5fba9092307df.json
@@ -1,13 +1,13 @@
 {
     "key": "group_5fba9092307df",
-    "title": "TV - Uitzending gemist (Vimeo)",
+    "title": "TV - Uitzending gemist",
     "fields": [
         {
-            "key": "field_5fba9099c14e2",
-            "label": "Vimeo client ID",
-            "name": "vimeo_client_id",
-            "type": "password",
-            "instructions": "",
+            "key": "field_62408073991e2",
+            "label": "Bunny CDN Library ID",
+            "name": "bunny_library_id",
+            "type": "number",
+            "instructions": "Vul het ID van de library in Bunny CDN in.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -15,33 +15,20 @@
                 "class": "",
                 "id": ""
             },
+            "default_value": "",
             "placeholder": "",
             "prepend": "",
-            "append": ""
+            "append": "",
+            "min": "",
+            "max": "",
+            "step": ""
         },
         {
-            "key": "field_5fba90b3e0bbc",
-            "label": "Vimeo client secret",
-            "name": "vimeo_client_secret",
+            "key": "field_623b82a61698a",
+            "label": "Bunny CDN API Key",
+            "name": "bunny_api_key",
             "type": "password",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "placeholder": "",
-            "prepend": "",
-            "append": ""
-        },
-        {
-            "key": "field_5fba90d3e0bbd",
-            "label": "Vimeo access token",
-            "name": "vimeo_access_token",
-            "type": "password",
-            "instructions": "",
+            "instructions": "Zoek de API Key op in het panel van Bunny CDN. Iedere Library heeft zijn eigen API key.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -71,5 +58,6 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1607697529
+    "show_in_rest": 0,
+    "modified": 1648394518
 }

--- a/streekomroep-acf-json/group_5fba9092307df.json
+++ b/streekomroep-acf-json/group_5fba9092307df.json
@@ -3,15 +3,34 @@
     "title": "TV - Uitzending gemist",
     "fields": [
         {
-            "key": "field_62408073991e2",
-            "label": "Bunny CDN Library ID",
-            "name": "bunny_library_id",
-            "type": "number",
-            "instructions": "Vul het ID van de library in Bunny CDN in.",
+            "key": "field_6246e1e8c4402",
+            "label": "Bunny CDN Hostname",
+            "name": "bunny_cdn_hostname",
+            "type": "text",
+            "instructions": "Te vinden onder Stream в†’ API в†’ CDN Hostname (mag ook CNAME naar een eigen domein zijn)",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
-                "width": "",
+                "width": "50",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_62408073991e2",
+            "label": "Bunny CDN Library ID",
+            "name": "bunny_cdn_library_id",
+            "type": "number",
+            "instructions": "Vul het ID van de library in Bunny CDN in. Te vinden onder Stream в†’ API в†’ Video Library ID",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "50",
                 "class": "",
                 "id": ""
             },
@@ -26,7 +45,7 @@
         {
             "key": "field_623b82a61698a",
             "label": "Bunny CDN API Key",
-            "name": "bunny_api_key",
+            "name": "bunny_cdn_api_key",
             "type": "password",
             "instructions": "Zoek de API Key op in het panel van Bunny CDN. Iedere Library heeft zijn eigen API key.",
             "required": 0,
@@ -59,5 +78,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1648394518
+    "modified": 1648812749
 }

--- a/style.css
+++ b/style.css
@@ -2,5 +2,5 @@
  * Theme Name: Streekomroep
  * Description: This is a WordPress theme made for Streekomroep ZuidWest in The Netherlands. It's made using Timber and Tailwind CSS and provides functionality for regional news, radio and tv broadcasts.
  * Author: Upstatement & Streekomroep ZuidWest
- * Version: 1.4.1
+ * Version: 1.5
 */


### PR DESCRIPTION
- [x] Update editorial back-end for 🐰
- [ ] Fetch video's from 🐰
- [ ] Fetch fragments from 🐰
- [ ] Populate metatags with values from 🐰
- [ ] Populate SEO data with values from 🐰
- [ ] Rename 'vi**m**eo_id' on the REST API to 'vi**d**eo_id'
- [ ] Hardcode `/tv/episodes/` REST API source to 'bunny'
- [ ] Don't get Fragments thumb from Bunny any more. It's not used much on the editorial side.
- [x] Version bump

[WIP]

** This runs on preview. now **