### PR TITLE
Exclude 'achterkant' articles on front page

### DIFF
--- a/page-front-page.php
+++ b/page-front-page.php
@@ -116,7 +116,7 @@ foreach ($context['options']['desking_blokken_voorpagina'] as &$block) {
                 'meta_query' => [
                     [
                         'key' => 'post_ranking',
-                        'value' => '2',
+                        'value' => ['2','6'],
                         'compare' => 'NOT LIKE',
                     ]
                 ]


### PR DESCRIPTION
This was some how not implemented.