### PR TITLE
Bunny CDN post-release fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "league/commonmark": "^2.4",
     "nesbot/carbon": "^2.66",
     "symfony/yaml": "^5.4",
-    "timber/timber": "1.*"
+    "timber/timber": "1.*",
+    "twig/markdown-extra": "^3.7"
   },
   "config": {
     "sort-packages": true,

--- a/fragment-thumbnail.php
+++ b/fragment-thumbnail.php
@@ -7,28 +7,15 @@ function zw_bunny_save_thumbnail($post_ID)
     if (get_post_type($post_ID) !== 'fragment') return;
 
     $url = get_field('fragment_url', $post_ID, false);
-    $id = zw_bunny_parse_url(trim($url));
-    if (!$id) {
+    $video = zw_bunny_get_video_from_url($url);
+
+    if (!$video->isAvailable()) {
         return;
     }
 
-    $credentials = zw_bunny_credentials_get($id->libraryId);
-    if (!$credentials) {
-        return;
-    }
+    update_field('fragment_duur', $video->getDuration(), $post_ID);
 
-    $video = zw_bunny_get_video($credentials, $id);
-    if (!$video) {
-        return;
-    }
-
-    if (!$video->status != \Streekomroep\BunnyVideo::STATUS_FINISHED) {
-        return;
-    }
-
-    update_field('fragment_duur', $video->length, $post_ID);
-
-    $poster = sprintf("%s/%s/%s", $credentials->hostname, $video->guid, $video->thumbnailFileName);
+    $poster = $video->getThumbnail();
 
     $thumbnail_id = get_post_thumbnail_id($post_ID);
     if ($thumbnail_id != 0) {
@@ -43,7 +30,7 @@ function zw_bunny_save_thumbnail($post_ID)
     }
 
     $file = [
-        'name' => $video->thumbnailFileName,
+        'name' => basename($poster),
         'tmp_name' => $tempPath,
     ];
 

--- a/fragment-thumbnail.php
+++ b/fragment-thumbnail.php
@@ -22,7 +22,7 @@ function zw_bunny_save_thumbnail($post_ID)
         return;
     }
 
-    if (!in_array($video->status, [\Streekomroep\BunnyVideo::STATUS_FINISHED, \Streekomroep\BunnyVideo::STATUS_RESOLUTION_FINISHED])) {
+    if (!$video->status != \Streekomroep\BunnyVideo::STATUS_FINISHED) {
         return;
     }
 

--- a/functions.php
+++ b/functions.php
@@ -391,7 +391,6 @@ function zw_rest_api_init()
                         'type' => 'application/x-mpegURL'
                     ];
 
-                    $d['vimeo_id'] = null;
                     $d['title'] = $video->getName();
                     $d['description'] = $video->getDescription();
                     $d['date'] = $video->getBroadcastDate()->format('c');

--- a/functions.php
+++ b/functions.php
@@ -129,7 +129,7 @@ function zw_bunny_get_video_from_url(string $url)
 function zw_filter_pre_oembed_result($default, $url, $args)
 {
     $video = zw_bunny_get_video_from_url(trim($url));
-    if (!$video->isAvailable()) {
+    if (!$video || !$video->isAvailable()) {
         return false;
     }
 

--- a/functions.php
+++ b/functions.php
@@ -1003,8 +1003,8 @@ function fragment_get_video($id)
     $video->uploadDate = get_the_date('c', $fragment);
     $video->thumbnailUrl = get_the_post_thumbnail_url($fragment);
 
-    $video = zw_bunny_get_video_from_url(trim(get_field('fragment_url', $id, false)));
-    $video->contentUrl = $video->getMP4Url();
+    $bunnyVideo = zw_bunny_get_video_from_url(trim(get_field('fragment_url', $id, false)));
+    $video->contentUrl = $bunnyVideo->getMP4Url();
 
     return $video;
 }

--- a/functions.php
+++ b/functions.php
@@ -916,11 +916,9 @@ function zw_project_cron()
 
 function zw_sort_videos(array $videos)
 {
-    $frontMatterParser = new \League\CommonMark\Extension\FrontMatter\FrontMatterParser(new \League\CommonMark\Extension\FrontMatter\Data\SymfonyYamlFrontMatterParser());
-
     /** @var Video[] $videos */
-    $videos = array_map(function ($a) use ($frontMatterParser) {
-        return new Video($a, $frontMatterParser);
+    $videos = array_map(function ($a) {
+        return new Video($a);
     }, $videos);
 
     // Filter videos that are still being uploaded or transcoded

--- a/functions.php
+++ b/functions.php
@@ -916,15 +916,9 @@ function zw_project_cron()
 
 function zw_sort_videos(array $videos)
 {
-    $environment = new League\CommonMark\Environment\Environment();
-    $environment->addExtension(new League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension());
-    $environment->addExtension(new League\CommonMark\Extension\FrontMatter\FrontMatterExtension());
-    $converter = new League\CommonMark\MarkdownConverter($environment);
-
-
     /** @var Video[] $videos */
-    $videos = array_map(function ($a) use($converter) {
-        return new Video($a, $converter);
+    $videos = array_map(function ($a) {
+        return new Video($a);
     }, $videos);
 
     // Filter videos that are still being uploaded or transcoded

--- a/functions.php
+++ b/functions.php
@@ -1213,7 +1213,13 @@ add_action('template_redirect', function () {
                 return 'video.episode';
             });
             add_action('wpseo_add_opengraph_images', function ($images) use ($video) {
-                $images->add_image(['url' => zw_thumbor($video->getThumbnail(), 1920, 1080)]);
+                $width = 1920;
+                $height = 1080;
+                $images->add_image([
+                    'url' => zw_thumbor($video->getThumbnail(), $width, $height),
+                    'width' => $width,
+                    'height' => $height
+                ]);
             });
             add_filter('wpseo_opengraph_url', $canonical);
 

--- a/functions.php
+++ b/functions.php
@@ -1213,7 +1213,7 @@ add_action('template_redirect', function () {
                 return 'video.episode';
             });
             add_action('wpseo_add_opengraph_images', function ($images) use ($video) {
-                $images->add_image(['url' => $video->getThumbnail()]);
+                $images->add_image(['url' => zw_thumbor($video->getThumbnail(), 1920, 1080)]);
             });
             add_filter('wpseo_opengraph_url', $canonical);
 

--- a/functions.php
+++ b/functions.php
@@ -916,9 +916,11 @@ function zw_project_cron()
 
 function zw_sort_videos(array $videos)
 {
+    $frontMatterParser = new \League\CommonMark\Extension\FrontMatter\FrontMatterParser(new \League\CommonMark\Extension\FrontMatter\Data\SymfonyYamlFrontMatterParser());
+
     /** @var Video[] $videos */
-    $videos = array_map(function ($a) {
-        return new Video($a);
+    $videos = array_map(function ($a) use ($frontMatterParser) {
+        return new Video($a, $frontMatterParser);
     }, $videos);
 
     // Filter videos that are still being uploaded or transcoded

--- a/functions.php
+++ b/functions.php
@@ -1263,5 +1263,35 @@ function jetpack_photon_url($image_url, $args = array(), $scheme = null)
     return $image_url;
 }
 
+function zw_thumbor($src, $width, $height)
+{
+    $key = get_option('imgproxy_key');
+    $salt = get_option('imgproxy_salt');
+    $host = get_option('imgproxy_url');
+
+    if (!$host)
+    {
+        return \Timber\ImageHelper::resize($src, $width, $height);
+    }
+
+    $resize = 'fill';
+    $gravity = 'ce'; // center
+    $enlarge = 1;
+    $extension = 'jpeg';
+
+    // Round dimensions
+    $width = (int)round($width);
+    $height = (int)round($height);
+
+    $encodedUrl = rtrim(strtr(base64_encode($src), '+/', '-_'), '=');
+    $path = "/rs:{$resize}:{$width}:{$height}:{$enlarge}/g:{$gravity}/{$encodedUrl}.{$extension}";
+
+    $keyBin = pack("H*" , $key);
+    $saltBin = pack("H*" , $salt);
+    $signature = rtrim(strtr(base64_encode(hash_hmac('sha256', $saltBin . $path, $keyBin, true)), '+/', '-_'), '=');
+
+    return $host . $signature . $path;
+}
+
 include 'modules/assets.php';
 include 'modules/tiled-gallery/tiled-gallery.php';

--- a/page-front-page.php
+++ b/page-front-page.php
@@ -41,13 +41,14 @@ foreach ($context['options']['desking_blokken_voorpagina'] as &$block) {
             $episodes_with_duplicate_shows = [];
             $latest_episode_per_show = [];
 
+            $credentials = zw_bunny_credentials_get(ZW_BUNNY_LIBRARY_TV);
             $deduplicate = $block['ontdubbel'] ? true : false;
             $videos_to_show = $block['aantal_videos'];
             foreach ($shows as $show) {
                 $videos = $show->meta(ZW_TV_META_VIDEOS);
                 if (!is_array($videos)) continue;
 
-                $videos_for_last_episode = $videos = zw_sort_videos($videos);
+                $videos_for_last_episode = $videos = zw_sort_videos($credentials, $videos);
                 $lastEpisode = array_shift($videos_for_last_episode);
                 if ($lastEpisode === null) continue;
 

--- a/single.php
+++ b/single.php
@@ -118,10 +118,10 @@ if ($timber_post->post_type == 'tv') {
             }, 11, 2);
             add_filter('wpseo_schema_imageobject', function ($data, $context) use ($video, $videoData) {
                 $thumb = $video->getThumbnail();
-                $data['url'] = $thumb;
 
                 $width = 1920;
                 $height = 1080;
+                $data['url'] = zw_thumbor($thumb, $width, $height);
                 $data['contentUrl'] = zw_thumbor($thumb, $width, $height);
                 $data['width'] = $width;
                 $data['height'] = $height;

--- a/single.php
+++ b/single.php
@@ -76,7 +76,9 @@ if ($timber_post->post_type == 'tv') {
     if (!is_array($videos)) {
         $videos = [];
     }
-    $videos = zw_sort_videos($videos);
+
+    $credentials = zw_bunny_credentials_get(ZW_BUNNY_LIBRARY_TV);
+    $videos = zw_sort_videos($credentials, $videos);
 
     $seasons = [];
     foreach ($videos as $video) {

--- a/single.php
+++ b/single.php
@@ -119,7 +119,12 @@ if ($timber_post->post_type == 'tv') {
             add_filter('wpseo_schema_imageobject', function ($data, $context) use ($video, $videoData) {
                 $thumb = $video->getThumbnail();
                 $data['url'] = $thumb;
-                $data['contentUrl'] = $thumb;
+
+                $width = 1920;
+                $height = 1080;
+                $data['contentUrl'] = zw_thumbor($thumb, $width, $height);
+                $data['width'] = $width;
+                $data['height'] = $height;
                 return $data;
             }, 10, 2);
             add_filter('wpseo_schema_webpage', function ($data, $context) use ($video, $videoData) {

--- a/single.php
+++ b/single.php
@@ -95,6 +95,7 @@ if ($timber_post->post_type == 'tv') {
 
     if (isset($_GET['v'])) {
         $videoId = $_GET['v'];
+        /** @var \Streekomroep\Video $video */
         $video = null;
         foreach ($videos as $item) {
             if ($item->getId() == $videoId) {
@@ -110,7 +111,7 @@ if ($timber_post->post_type == 'tv') {
             $videoData->duration = $video->getDuration();
             $videoData->uploadDate = $video->getBroadcastDate()->format('c');
             $videoData->thumbnailUrl = $video->getThumbnail();
-            $videoData->contentUrl = $video->getFile();
+            $videoData->contentUrl = $video->getMP4Url();
             add_filter('wpseo_schema_graph_pieces', function ($pieces, $context) use ($videoData) {
                 $pieces[] = new VideoObject($videoData);
                 return $pieces;

--- a/src/BunnyVideo.php
+++ b/src/BunnyVideo.php
@@ -4,8 +4,7 @@ namespace Streekomroep;
 
 class BunnyVideo
 {
-    const STATUS_FINISHED = 3;
-    const STATUS_RESOLUTION_FINISHED = 4;
+    const STATUS_FINISHED = 4;
 
     public int $videoLibraryId;
     public string $guid;

--- a/src/Site.php
+++ b/src/Site.php
@@ -2,6 +2,11 @@
 
 namespace Streekomroep;
 
+use Twig\Extra\Markdown\DefaultMarkdown;
+use Twig\Extra\Markdown\MarkdownExtension;
+use Twig\Extra\Markdown\MarkdownRuntime;
+use Twig\RuntimeLoader\RuntimeLoaderInterface;
+
 /**
  * We're going to configure our theme inside of a subclass of Timber\Site
  * You can move this to its own file and include here via php's include("MySite.php")
@@ -189,6 +194,15 @@ class Site extends \Timber\Site
      */
     public function add_to_twig($twig)
     {
+        $twig->addExtension(new MarkdownExtension());
+        $twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
+            public function load($class) {
+                if (MarkdownRuntime::class === $class) {
+                    return new MarkdownRuntime(new DefaultMarkdown());
+                }
+            }
+        });
+
         $twig->addExtension(new \Twig\Extension\StringLoaderExtension());
         $twig->addFilter(new \Twig\TwigFilter('format_schedule', [$this, 'format_schedule']));
         $twig->addFunction(new \Twig\TwigFunction('icon', [$this, 'get_icon']));

--- a/src/Site.php
+++ b/src/Site.php
@@ -160,32 +160,7 @@ class Site extends \Timber\Site
 
     public function thumbor($src, $width, $height)
     {
-        $key = get_option('imgproxy_key');
-        $salt = get_option('imgproxy_salt');
-        $host = get_option('imgproxy_url');
-
-        if (!$host)
-        {
-            return \Timber\ImageHelper::resize($src, $width, $height);
-        }
-
-        $resize = 'fill';
-        $gravity = 'ce'; // center
-        $enlarge = 1;
-        $extension = 'jpeg';
-
-        // Round dimensions
-        $width = (int)round($width);
-        $height = (int)round($height);
-
-        $encodedUrl = rtrim(strtr(base64_encode($src), '+/', '-_'), '=');
-        $path = "/rs:{$resize}:{$width}:{$height}:{$enlarge}/g:{$gravity}/{$encodedUrl}.{$extension}";
-
-        $keyBin = pack("H*" , $key);
-        $saltBin = pack("H*" , $salt);
-        $signature = rtrim(strtr(base64_encode(hash_hmac('sha256', $saltBin . $path, $keyBin, true)), '+/', '-_'), '=');
-
-        return $host . $signature . $path;
+        return zw_thumbor($src, $width, $height);
     }
 
     /** This is where you can add your own functions to twig.

--- a/src/Video.php
+++ b/src/Video.php
@@ -110,12 +110,6 @@ class Video
         return $this->data->length;
     }
 
-    public function getFile()
-    {
-        // TODO: return mp4 url
-        return '';
-    }
-
     public function getPlaylistUrl()
     {
         return sprintf("%s/%s/playlist.m3u8", $this->credentials->hostname, $this->data->guid);

--- a/src/Video.php
+++ b/src/Video.php
@@ -3,11 +3,8 @@
 namespace Streekomroep;
 
 use Exception;
-use League\CommonMark\ConverterInterface;
-use League\CommonMark\Extension\FrontMatter\Data\SymfonyYamlFrontMatterParser;
 use League\CommonMark\Extension\FrontMatter\Exception\InvalidFrontMatterException;
 use League\CommonMark\Extension\FrontMatter\FrontMatterParser;
-use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 
 class Video
 {
@@ -18,7 +15,7 @@ class Video
     private ?\DateTime $broadcastDate = null;
 
 
-    public function __construct($data)
+    public function __construct($data, FrontMatterParser $frontMatterParser)
     {
         $this->data = $data;
 
@@ -34,7 +31,6 @@ class Video
         }
 
         try {
-            $frontMatterParser = new FrontMatterParser(new SymfonyYamlFrontMatterParser());
             $result = $frontMatterParser->parse($description);
             $this->yaml = $result->getFrontMatter();
             $this->description = $result->getContent();

--- a/src/Video.php
+++ b/src/Video.php
@@ -3,6 +3,7 @@
 namespace Streekomroep;
 
 use Exception;
+use League\CommonMark\Extension\FrontMatter\Data\SymfonyYamlFrontMatterParser;
 use League\CommonMark\Extension\FrontMatter\Exception\InvalidFrontMatterException;
 use League\CommonMark\Extension\FrontMatter\FrontMatterParser;
 
@@ -15,7 +16,7 @@ class Video
     private ?\DateTime $broadcastDate = null;
 
 
-    public function __construct($data, FrontMatterParser $frontMatterParser)
+    public function __construct($data)
     {
         $this->data = $data;
 
@@ -31,6 +32,7 @@ class Video
         }
 
         try {
+            $frontMatterParser = new FrontMatterParser(new SymfonyYamlFrontMatterParser());
             $result = $frontMatterParser->parse($description);
             $this->yaml = $result->getFrontMatter();
             $this->description = $result->getContent();

--- a/style.css
+++ b/style.css
@@ -2,5 +2,5 @@
  * Theme Name: Streekomroep
  * Description: This is a WordPress theme made for Streekomroep ZuidWest in the Netherlands. It's made using Timber and Tailwind CSS and provides functionality for regional news, radio and television broadcasts.
  * Author: Streekomroep ZuidWest
- * Version: 1.6.4
+ * Version: 1.6.5
 */

--- a/templates/single-fragment.twig
+++ b/templates/single-fragment.twig
@@ -48,7 +48,7 @@
     </article>
 
     {% if local %}
-        <div class="bg-white dark:bg-gray-800 text-black dark:text-white border-t border-gray-300/50 dark:border-gray-700/50">
+        <div class="bg-gray-800 text-white border-t border-transparent dark:border-gray-700/50">
             <div class="w-full mx-auto max-w-960 py-4 px-4">
                 <h2 class="font-bold text-3xl pb-4">Meer nieuws uit {{ local.region }}</h2>
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4">

--- a/templates/single-tv-video.twig
+++ b/templates/single-tv-video.twig
@@ -13,7 +13,7 @@
         {% if video.description %}
             <div class="mx-auto max-w-3xl px-4 lg:px-0 mt-6 pb-6">
                 <div class="prose dark:prose-invert md:prose-lg max-w-none text-black dark:text-white">
-                    {{ video.description | raw }}
+                    {{ video.description | markdown_to_html }}
                 </div>
             </div>
         {% endif %}

--- a/templates/single-tv.twig
+++ b/templates/single-tv.twig
@@ -34,7 +34,11 @@
                             {% for video in videos %}
                                 <article>
                                     <a href="?v={{ video.id }}">
-                                        <img src="{{ video.thumbnail }}" alt="{{ video.name }}" loading="lazy"/>
+                                        {% set width = 220 %}
+                                        <img class="w-full h-full object-contain" loading="lazy" alt="{{ video.name }}"
+                                             width="{{ width }}" height="{{ (width / 16 * 9)|round }}"
+                                             src="{{ video.thumbnail|thumbor(width, width / 16 * 9) }}"
+                                             srcset="{{ video.thumbnail|thumbor(width * 2, (width * 2) / 16 * 9) }} 2x"/>
                                         <h3 class="font-bold mt-2 :text-gray-200">{{ video.name }}</h3>
                                     </a>
                                 </article>

--- a/templates/single-tv.twig
+++ b/templates/single-tv.twig
@@ -35,7 +35,7 @@
                                 <article>
                                     <a href="?v={{ video.id }}">
                                         {% set width = 220 %}
-                                        <img class="w-full h-full object-contain" loading="lazy" alt="{{ video.name }}"
+                                        <img class="w-full object-contain" loading="lazy" alt="{{ video.name }}"
                                              width="{{ width }}" height="{{ (width / 16 * 9)|round }}"
                                              src="{{ video.thumbnail|thumbor(width, width / 16 * 9) }}"
                                              srcset="{{ video.thumbnail|thumbor(width * 2, (width * 2) / 16 * 9) }} 2x"/>


### PR DESCRIPTION
- [x] Create regex redirects mapping Vimeo ID's to Bunny ID's
- [x] Give metatags and schema tags clean text instead of html
- [x] Fix video delivery via json-api for app (put hls and mp4 files in, we don't want to give the app guys an API key for Bunny)
- [x] Only consider video's with `STATUS_FINISHED` (not `RESOLUTION_FINISHED`) available. Otherwise we're serving low quality variants forever due to the oembeds being cached in WP.
- [x] Resize thumbs in cards using imgproxy (responsive images, `@2x` too!)
- [x] Give `og:image` for tv video's a hardcoded size of 1920x1080 and use imgproxy to always force this size
- [x] Put highest resolution mp4 file in `<video>` object for Chromecast and crawlers
- [x] Put highest resolution mp4 in `contenturl` for schema data
- [ ] Make inline embeds work again

WIP