### PR TITLE
fix: hide Tekst TV content when no days are selected

### DIFF
--- a/lib/teksttv.php
+++ b/lib/teksttv.php
@@ -53,7 +53,7 @@ class TekstTVAPI
     private function is_allowed_on_day(?array $allowed_days, ?\DateTimeInterface $date = null): bool
     {
         if (empty($allowed_days)) {
-            return true;
+            return false;
         }
 
         $date = $date ?? current_datetime();

--- a/style.css
+++ b/style.css
@@ -2,5 +2,5 @@
  * Theme Name: Streekomroep
  * Description: This is a WordPress theme made for Streekomroep ZuidWest in the Netherlands. It's made using Timber and Tailwind CSS and provides functionality for regional news, radio and television broadcasts.
  * Author: Streekomroep ZuidWest
- * Version: 1.13.1
+ * Version: 1.13.2
 */


### PR DESCRIPTION
## Summary
- Changes `is_allowed_on_day()` to return `false` when no days are selected, instead of `true`
- This means slides and posts with an empty days checkbox are no longer shown
- All ACF day checkboxes already default to all 7 days selected, so existing content is unaffected

Closes #125