### PR TITLE
fix: update Timber to 2.4.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ This is a WordPress theme with some hard dependencies. You can't run it without 
 
 ## Hard dependencies
 Install these before activating the theme:
-- Timber 2.3: Bundled via Composer, no separate installation needed
+- Timber 2.4.1: Bundled via Composer, no separate installation needed
 - Advanced Custom Fields Pro 6.3.x: [[purchase](https://www.advancedcustomfields.com/pro/)]
 - Classic Editor 1.x: [[free download](https://wordpress.org/plugins/classic-editor/)] _(we are giving the block editor more time to stabilize)_
 - Yoast SEO Premium 24.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To reset: `docker compose down -v` (removes database)
 
 ### Hard dependencies
 Install these before activating the theme:
-- Timber 2.3: [Bundled, if you build yourself [use composer](https://timber.github.io/docs/v2/installation/installation/)]
+- Timber 2.4.1: [Bundled; if you build yourself, use composer](https://timber.github.io/docs/v2/installation/installation/)
 - Advanced Custom Fields Pro 6.3.x: [[purchase](https://www.advancedcustomfields.com/pro/)]
 - Classic Editor 1.x: [[free download](https://wordpress.org/plugins/classic-editor/)] _(we are giving the block editor more time to stabilize)_
 - Yoast SEO Premium 24.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "league/commonmark": "^2.4",
     "nesbot/carbon": "^3.11",
     "symfony/yaml": "^5.4",
-    "timber/timber": "~2.4.0",
+    "timber/timber": "~2.4.1",
     "twig/markdown-extra": "^3.7"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe2502da8d910504f37fbfdfe616582b",
+    "content-hash": "61ad7e702d2ee21387ba49f77372ef38",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -780,16 +780,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -802,7 +802,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -827,7 +827,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -839,15 +839,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -906,7 +910,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -930,7 +934,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -991,7 +995,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1015,7 +1019,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -1075,7 +1079,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1360,16 +1364,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.45",
+            "version": "v5.4.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e"
+                "reference": "b0b27055f055f0d314c5c68ed0c10f0bbd90aee0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a454d47278cc16a5db371fe73ae66a78a633371e",
-                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b0b27055f055f0d314c5c68ed0c10f0bbd90aee0",
+                "reference": "b0b27055f055f0d314c5c68ed0c10f0bbd90aee0",
                 "shasum": ""
             },
             "require": {
@@ -1415,7 +1419,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.45"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.52"
             },
             "funding": [
                 {
@@ -1427,29 +1431,33 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2026-05-15T06:40:16+00:00"
         },
         {
             "name": "timber/timber",
-            "version": "v2.4.0",
+            "version": "v2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/timber/timber.git",
-                "reference": "44c7171d154ee697bab416a31852b9340845cc7f"
+                "reference": "35b869a7f1029d0b54e10066eb0da04c9c54e46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/timber/timber/zipball/44c7171d154ee697bab416a31852b9340845cc7f",
-                "reference": "44c7171d154ee697bab416a31852b9340845cc7f",
+                "url": "https://api.github.com/repos/timber/timber/zipball/35b869a7f1029d0b54e10066eb0da04c9c54e46f",
+                "reference": "35b869a7f1029d0b54e10066eb0da04c9c54e46f",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.2",
-                "twig/twig": "^3.19"
+                "twig/twig": "^3.26"
             },
             "require-dev": {
                 "composer/installers": "^2",
@@ -1480,7 +1488,7 @@
                 "squizlabs/php_codesniffer": "^3.0",
                 "symplify/easy-coding-standard": "^13",
                 "szepeviktor/phpstan-wordpress": "^2",
-                "twig/cache-extra": "^3.17",
+                "twig/cache-extra": "^3.21",
                 "wp-plugin/advanced-custom-fields": "^6.5",
                 "wp-plugin/co-authors-plus": "^3.6"
             },
@@ -1548,20 +1556,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-04-20T08:31:34+00:00"
+            "time": "2026-05-20T13:20:16+00:00"
         },
         {
             "name": "twig/markdown-extra",
-            "version": "v3.24.0",
+            "version": "v3.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/markdown-extra.git",
-                "reference": "67a11120356e034a5bbc70c5b9b9a4d0f31ca06e"
+                "reference": "e3f3fd0836eb6c39457da22c8a76abaac62692b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/markdown-extra/zipball/67a11120356e034a5bbc70c5b9b9a4d0f31ca06e",
-                "reference": "67a11120356e034a5bbc70c5b9b9a4d0f31ca06e",
+                "url": "https://api.github.com/repos/twigphp/markdown-extra/zipball/e3f3fd0836eb6c39457da22c8a76abaac62692b9",
+                "reference": "e3f3fd0836eb6c39457da22c8a76abaac62692b9",
                 "shasum": ""
             },
             "require": {
@@ -1608,7 +1616,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/twigphp/markdown-extra/tree/v3.24.0"
+                "source": "https://github.com/twigphp/markdown-extra/tree/v3.26.0"
             },
             "funding": [
                 {
@@ -1620,20 +1628,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-07T08:07:38+00:00"
+            "time": "2026-05-15T13:14:02+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.24.0",
+            "version": "v3.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0"
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6769aefb305efef849dc25c9fd1653358c148f0",
-                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
                 "shasum": ""
             },
             "require": {
@@ -1688,7 +1696,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.24.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
             },
             "funding": [
                 {
@@ -1700,7 +1708,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-17T21:31:11+00:00"
+            "time": "2026-05-20T07:31:59+00:00"
         }
     ],
     "packages-dev": [

--- a/front-page.php
+++ b/front-page.php
@@ -8,7 +8,7 @@ $context = Timber::context();
 $timber_post = Timber::get_post();
 $context['post'] = $timber_post;
 
-if ($context['options']['desking_blokken_voorpagina'] === false) {
+if (empty($context['options']['desking_blokken_voorpagina']) || !is_array($context['options']['desking_blokken_voorpagina'])) {
     $context['options']['desking_blokken_voorpagina'] = [];
 }
 

--- a/functions.php
+++ b/functions.php
@@ -389,7 +389,7 @@ function zw_rest_api_init()
 
             return [
                 'fm' => [
-                    'now' => $decode($currentRadioBroadcast->getName()),
+                    'now' => $currentRadioBroadcast ? $decode($currentRadioBroadcast->getName()) : null,
                     'next' => $nextBroadcast ? $decode($nextBroadcast->getName()) : null,
                 ],
                 'tv' => [

--- a/src/BroadcastSchedule.php
+++ b/src/BroadcastSchedule.php
@@ -97,7 +97,7 @@ class BroadcastSchedule
             }
         }
 
-        $fillerTitle = get_field('radio_geen_programma_naam', 'option') ?: 'Geen programma';
+        $fillerTitle = get_field('radio_geen_programma_naam', 'option') ?: 'Non-stop';
         foreach ($this->days as $day) {
             $time = (new Carbon($day->date))->setTime(0, 0, 0);
             $newBroadcasts = [];

--- a/src/BroadcastSchedule.php
+++ b/src/BroadcastSchedule.php
@@ -97,7 +97,7 @@ class BroadcastSchedule
             }
         }
 
-        $fillerTitle = get_field('radio_geen_programma_naam', 'option');
+        $fillerTitle = get_field('radio_geen_programma_naam', 'option') ?: 'Geen programma';
         foreach ($this->days as $day) {
             $time = (new Carbon($day->date))->setTime(0, 0, 0);
             $newBroadcasts = [];

--- a/src/Site.php
+++ b/src/Site.php
@@ -56,7 +56,7 @@ class Site extends \Timber\Site
         $context['footer'] = Timber::get_menu('footer');
         $context['socials'] = zw_get_socials();
         $context['site'] = $this;
-        $context['options'] = get_fields('option');
+        $context['options'] = get_fields('option') ?: [];
         return $context;
     }
 


### PR DESCRIPTION
## Summary
- update Timber to 2.4.1 and lock Twig/security-related dependencies
- update Timber version references in README/INSTALL
- harden empty ACF option and broadcast schedule fallbacks found during runtime smoke testing

## Verification
- composer audit
- composer lint:twig
- vendor/bin/phpcs --standard=phpcs.xml .
- PHP syntax check over theme PHP files
- npm run build:tailwind
- Docker smoke test: homepage, search, and /index.php?rest_route=/zw/v1/broadcast_data return HTTP 200 without PHP warning/fatal markers