### PR TITLE
fix: add imgproxy settings and highlighted fragment poster override

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Configure imgproxy in WordPress under Settings > Media:
 - `zw_imgproxy_salt`
 - `zw_imgproxy_url`
 
-The `zw_imgproxy_url` value is normalized (`https://` is added when no scheme is entered, and a trailing slash is enforced). Normalization runs both when saving the option and when reading the constant fallback, so the constants below also work without a trailing slash. Invalid URLs are rejected with an admin notice.
+The `zw_imgproxy_url` value is normalized (`https://` is added when no scheme is entered, and a trailing slash is enforced). Normalization runs both when saving the option and when reading the constant fallback, so the constants below also work without a trailing slash. Empty WordPress options are backfilled from the matching constants in wp-admin. Invalid URLs are rejected with an admin notice.
 
-For deployments that cannot store these values in WordPress options, the following constants are still supported as a per-key fallback when the matching option is empty:
+For deployments that still define these values in `wp-config.php`, the following constants are still supported as a per-key fallback when the matching option is empty:
 
 ```php
 define('IMGPROXY_KEY', 'your-hex-key');

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ The theme supports [imgproxy](https://imgproxy.net/) for on-the-fly image resizi
 
 Configure imgproxy in WordPress under Settings > Media:
 
-- `imgproxy_key`
-- `imgproxy_salt`
-- `imgproxy_url`
+- `zw_imgproxy_key`
+- `zw_imgproxy_salt`
+- `zw_imgproxy_url`
 
-The `imgproxy_url` value is normalized with `https://` when no scheme is entered and always gets a trailing slash.
+The `zw_imgproxy_url` value is normalized (`https://` is added when no scheme is entered, and a trailing slash is enforced). Normalization runs both when saving the option and when reading the constant fallback, so the constants below also work without a trailing slash. Invalid URLs are rejected with an admin notice.
 
-For deployments that cannot store these values in WordPress options, the following constants are still supported as a fallback when the matching option is empty:
+For deployments that cannot store these values in WordPress options, the following constants are still supported as a per-key fallback when the matching option is empty:
 
 ```php
 define('IMGPROXY_KEY', 'your-hex-key');

--- a/README.md
+++ b/README.md
@@ -62,7 +62,15 @@ Some first-party plugins developed by Streekomroep ZuidWest add extra functional
 
 The theme supports [imgproxy](https://imgproxy.net/) for on-the-fly image resizing with signed URLs. When configured, all images rendered with the `|imgproxy` Twig filter are served through imgproxy. Without it, the theme falls back to Timber's built-in image resizing.
 
-To enable, add the following constants to `wp-config.php`, above the `/* That's all, stop editing! */` line:
+Configure imgproxy in WordPress under Settings > Media:
+
+- `imgproxy_key`
+- `imgproxy_salt`
+- `imgproxy_url`
+
+The `imgproxy_url` value is normalized with `https://` when no scheme is entered and always gets a trailing slash.
+
+For deployments that cannot store these values in WordPress options, the following constants are still supported as a fallback when the matching option is empty:
 
 ```php
 define('IMGPROXY_KEY', 'your-hex-key');

--- a/functions.php
+++ b/functions.php
@@ -834,7 +834,7 @@ function zw_render_imgproxy_settings_field($args)
     }
 }
 
-function zw_sanitize_imgproxy_url($url)
+function zw_normalize_imgproxy_url($url)
 {
     $url = trim((string) $url);
 
@@ -849,6 +849,28 @@ function zw_sanitize_imgproxy_url($url)
     $sanitized = esc_url_raw($url);
 
     if ($sanitized === '') {
+        return '';
+    }
+
+    $parsed = wp_parse_url($sanitized);
+
+    if (!is_array($parsed) || empty($parsed['host'])) {
+        return '';
+    }
+
+    $scheme = isset($parsed['scheme']) ? strtolower($parsed['scheme']) : '';
+    if ($scheme !== 'http' && $scheme !== 'https') {
+        return '';
+    }
+
+    return trailingslashit($sanitized);
+}
+
+function zw_sanitize_imgproxy_url($url)
+{
+    $normalized = zw_normalize_imgproxy_url($url);
+
+    if ($normalized === '' && trim((string) $url) !== '') {
         add_settings_error(
             'zw_imgproxy_url',
             'invalid_url',
@@ -857,7 +879,7 @@ function zw_sanitize_imgproxy_url($url)
         return (string) get_option('zw_imgproxy_url', '');
     }
 
-    return trailingslashit($sanitized);
+    return $normalized;
 }
 
 function zw_get_imgproxy_setting($option, $constant)
@@ -937,7 +959,7 @@ function zw_imgproxy($src, $width, $height)
 {
     $key = zw_get_imgproxy_setting('zw_imgproxy_key', 'IMGPROXY_KEY');
     $salt = zw_get_imgproxy_setting('zw_imgproxy_salt', 'IMGPROXY_SALT');
-    $host = zw_sanitize_imgproxy_url(zw_get_imgproxy_setting('zw_imgproxy_url', 'IMGPROXY_URL'));
+    $host = zw_normalize_imgproxy_url(zw_get_imgproxy_setting('zw_imgproxy_url', 'IMGPROXY_URL'));
 
     if (!$host || !$key || !$salt) {
         if ($host || $key || $salt) {

--- a/functions.php
+++ b/functions.php
@@ -720,6 +720,154 @@ function zw_seo_article_add_region($data, $context)
 add_filter('big_image_size_threshold', '__return_false');
 add_filter('img_caption_shortcode_width', '__return_false');
 
+add_action('admin_init', 'zw_register_imgproxy_media_settings');
+
+function zw_register_imgproxy_media_settings()
+{
+    register_setting(
+        'media',
+        'imgproxy_key',
+        [
+            'type' => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default' => '',
+        ]
+    );
+
+    register_setting(
+        'media',
+        'imgproxy_salt',
+        [
+            'type' => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default' => '',
+        ]
+    );
+
+    register_setting(
+        'media',
+        'imgproxy_url',
+        [
+            'type' => 'string',
+            'sanitize_callback' => 'zw_sanitize_imgproxy_url',
+            'default' => '',
+        ]
+    );
+
+    add_settings_section(
+        'zw_imgproxy_settings',
+        __('Imgproxy', 'streekomroep'),
+        'zw_render_imgproxy_settings_section',
+        'media'
+    );
+
+    add_settings_field(
+        'imgproxy_key',
+        __('imgproxy_key', 'streekomroep'),
+        'zw_render_imgproxy_settings_field',
+        'media',
+        'zw_imgproxy_settings',
+        [
+            'label_for' => 'imgproxy_key',
+            'option' => 'imgproxy_key',
+            'description' => __('Hex-encoded key voor ondertekende imgproxy-URL\'s.', 'streekomroep'),
+            'autocomplete' => 'off',
+        ]
+    );
+
+    add_settings_field(
+        'imgproxy_salt',
+        __('imgproxy_salt', 'streekomroep'),
+        'zw_render_imgproxy_settings_field',
+        'media',
+        'zw_imgproxy_settings',
+        [
+            'label_for' => 'imgproxy_salt',
+            'option' => 'imgproxy_salt',
+            'description' => __('Hex-encoded salt voor ondertekende imgproxy-URL\'s.', 'streekomroep'),
+            'autocomplete' => 'off',
+        ]
+    );
+
+    add_settings_field(
+        'imgproxy_url',
+        __('imgproxy_url', 'streekomroep'),
+        'zw_render_imgproxy_settings_field',
+        'media',
+        'zw_imgproxy_settings',
+        [
+            'label_for' => 'imgproxy_url',
+            'option' => 'imgproxy_url',
+            'description' => __('Basis-URL van imgproxy, inclusief https:// en trailing slash.', 'streekomroep'),
+            'type' => 'url',
+            'placeholder' => 'https://imgproxy.example.com/',
+        ]
+    );
+}
+
+function zw_render_imgproxy_settings_section()
+{
+    echo '<p>' . esc_html__('Laat deze velden leeg om Timber image resizing te gebruiken.', 'streekomroep') . '</p>';
+}
+
+function zw_render_imgproxy_settings_field($args)
+{
+    $option = $args['option'];
+    $type = $args['type'] ?? 'text';
+    $value = get_option($option, '');
+    $placeholder = $args['placeholder'] ?? '';
+    $autocomplete = $args['autocomplete'] ?? '';
+
+    printf(
+        '<input name="%1$s" id="%1$s" type="%2$s" value="%3$s" class="regular-text code" placeholder="%4$s" autocomplete="%5$s">',
+        esc_attr($option),
+        esc_attr($type),
+        esc_attr($value),
+        esc_attr($placeholder),
+        esc_attr($autocomplete)
+    );
+
+    if (!empty($args['description'])) {
+        echo '<p class="description">' . esc_html($args['description']) . '</p>';
+    }
+}
+
+function zw_sanitize_imgproxy_url($url)
+{
+    $url = trim((string) $url);
+
+    if ($url === '') {
+        return '';
+    }
+
+    if (!preg_match('#^https?://#i', $url)) {
+        $url = 'https://' . ltrim($url, '/');
+    }
+
+    return trailingslashit(esc_url_raw($url));
+}
+
+function zw_get_imgproxy_setting($option, $constant)
+{
+    $value = trim((string) get_option($option, ''));
+
+    if ($value !== '') {
+        return $value;
+    }
+
+    if (!defined($constant)) {
+        return '';
+    }
+
+    $value = constant($constant);
+
+    if (!is_scalar($value)) {
+        return '';
+    }
+
+    return trim((string) $value);
+}
+
 /**
  * Remove block editor (Gutenberg) CSS
  * This function dequeues the CSS for the block editor which this theme does not use
@@ -750,9 +898,9 @@ add_action('wp_enqueue_scripts', 'zw_add_videojs');
 
 function zw_imgproxy($src, $width, $height)
 {
-    $key = defined('IMGPROXY_KEY') ? IMGPROXY_KEY : '';
-    $salt = defined('IMGPROXY_SALT') ? IMGPROXY_SALT : '';
-    $host = defined('IMGPROXY_URL') ? IMGPROXY_URL : '';
+    $key = zw_get_imgproxy_setting('imgproxy_key', 'IMGPROXY_KEY');
+    $salt = zw_get_imgproxy_setting('imgproxy_salt', 'IMGPROXY_SALT');
+    $host = zw_sanitize_imgproxy_url(zw_get_imgproxy_setting('imgproxy_url', 'IMGPROXY_URL'));
 
     if (!$host || !$key || !$salt) {
         return \Timber\ImageHelper::resize($src, $width, $height);

--- a/functions.php
+++ b/functions.php
@@ -805,6 +805,8 @@ function zw_register_imgproxy_media_settings()
             'placeholder' => 'https://imgproxy.example.com/',
         ]
     );
+
+    zw_backfill_imgproxy_media_settings();
 }
 
 function zw_render_imgproxy_settings_section()
@@ -882,14 +884,8 @@ function zw_sanitize_imgproxy_url($url)
     return $normalized;
 }
 
-function zw_get_imgproxy_setting($option, $constant)
+function zw_get_imgproxy_constant($constant)
 {
-    $value = trim((string) get_option($option, ''));
-
-    if ($value !== '') {
-        return $value;
-    }
-
     if (!defined($constant)) {
         return '';
     }
@@ -903,6 +899,49 @@ function zw_get_imgproxy_setting($option, $constant)
     return trim((string) $value);
 }
 
+function zw_backfill_imgproxy_setting($option, $constant, $sanitize_callback)
+{
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+
+    if (trim((string) get_option($option, '')) !== '') {
+        return;
+    }
+
+    $value = zw_get_imgproxy_constant($constant);
+
+    if ($value === '') {
+        return;
+    }
+
+    $value = call_user_func($sanitize_callback, $value);
+
+    if ($value === '') {
+        return;
+    }
+
+    update_option($option, $value);
+}
+
+function zw_backfill_imgproxy_media_settings()
+{
+    zw_backfill_imgproxy_setting('zw_imgproxy_key', 'IMGPROXY_KEY', 'sanitize_text_field');
+    zw_backfill_imgproxy_setting('zw_imgproxy_salt', 'IMGPROXY_SALT', 'sanitize_text_field');
+    zw_backfill_imgproxy_setting('zw_imgproxy_url', 'IMGPROXY_URL', 'zw_normalize_imgproxy_url');
+}
+
+function zw_get_imgproxy_setting($option, $constant)
+{
+    $value = trim((string) get_option($option, ''));
+
+    if ($value !== '') {
+        return $value;
+    }
+
+    return zw_get_imgproxy_constant($constant);
+}
+
 add_action('admin_notices', 'zw_imgproxy_admin_notice');
 
 function zw_imgproxy_admin_notice()
@@ -913,7 +952,7 @@ function zw_imgproxy_admin_notice()
 
     $key = zw_get_imgproxy_setting('zw_imgproxy_key', 'IMGPROXY_KEY');
     $salt = zw_get_imgproxy_setting('zw_imgproxy_salt', 'IMGPROXY_SALT');
-    $host = zw_get_imgproxy_setting('zw_imgproxy_url', 'IMGPROXY_URL');
+    $host = zw_normalize_imgproxy_url(zw_get_imgproxy_setting('zw_imgproxy_url', 'IMGPROXY_URL'));
 
     $configured = (int) ($key !== '') + (int) ($salt !== '') + (int) ($host !== '');
 

--- a/functions.php
+++ b/functions.php
@@ -726,7 +726,7 @@ function zw_register_imgproxy_media_settings()
 {
     register_setting(
         'media',
-        'imgproxy_key',
+        'zw_imgproxy_key',
         [
             'type' => 'string',
             'sanitize_callback' => 'sanitize_text_field',
@@ -736,7 +736,7 @@ function zw_register_imgproxy_media_settings()
 
     register_setting(
         'media',
-        'imgproxy_salt',
+        'zw_imgproxy_salt',
         [
             'type' => 'string',
             'sanitize_callback' => 'sanitize_text_field',
@@ -746,7 +746,7 @@ function zw_register_imgproxy_media_settings()
 
     register_setting(
         'media',
-        'imgproxy_url',
+        'zw_imgproxy_url',
         [
             'type' => 'string',
             'sanitize_callback' => 'zw_sanitize_imgproxy_url',
@@ -762,42 +762,44 @@ function zw_register_imgproxy_media_settings()
     );
 
     add_settings_field(
-        'imgproxy_key',
+        'zw_imgproxy_key',
         __('imgproxy_key', 'streekomroep'),
         'zw_render_imgproxy_settings_field',
         'media',
         'zw_imgproxy_settings',
         [
-            'label_for' => 'imgproxy_key',
-            'option' => 'imgproxy_key',
+            'label_for' => 'zw_imgproxy_key',
+            'option' => 'zw_imgproxy_key',
             'description' => __('Hex-encoded key voor ondertekende imgproxy-URL\'s.', 'streekomroep'),
+            'type' => 'password',
             'autocomplete' => 'off',
         ]
     );
 
     add_settings_field(
-        'imgproxy_salt',
+        'zw_imgproxy_salt',
         __('imgproxy_salt', 'streekomroep'),
         'zw_render_imgproxy_settings_field',
         'media',
         'zw_imgproxy_settings',
         [
-            'label_for' => 'imgproxy_salt',
-            'option' => 'imgproxy_salt',
+            'label_for' => 'zw_imgproxy_salt',
+            'option' => 'zw_imgproxy_salt',
             'description' => __('Hex-encoded salt voor ondertekende imgproxy-URL\'s.', 'streekomroep'),
+            'type' => 'password',
             'autocomplete' => 'off',
         ]
     );
 
     add_settings_field(
-        'imgproxy_url',
+        'zw_imgproxy_url',
         __('imgproxy_url', 'streekomroep'),
         'zw_render_imgproxy_settings_field',
         'media',
         'zw_imgproxy_settings',
         [
-            'label_for' => 'imgproxy_url',
-            'option' => 'imgproxy_url',
+            'label_for' => 'zw_imgproxy_url',
+            'option' => 'zw_imgproxy_url',
             'description' => __('Basis-URL van imgproxy, inclusief https:// en trailing slash.', 'streekomroep'),
             'type' => 'url',
             'placeholder' => 'https://imgproxy.example.com/',
@@ -844,7 +846,18 @@ function zw_sanitize_imgproxy_url($url)
         $url = 'https://' . ltrim($url, '/');
     }
 
-    return trailingslashit(esc_url_raw($url));
+    $sanitized = esc_url_raw($url);
+
+    if ($sanitized === '') {
+        add_settings_error(
+            'zw_imgproxy_url',
+            'invalid_url',
+            __('De opgegeven imgproxy URL is ongeldig en is niet opgeslagen.', 'streekomroep')
+        );
+        return (string) get_option('zw_imgproxy_url', '');
+    }
+
+    return trailingslashit($sanitized);
 }
 
 function zw_get_imgproxy_setting($option, $constant)
@@ -866,6 +879,30 @@ function zw_get_imgproxy_setting($option, $constant)
     }
 
     return trim((string) $value);
+}
+
+add_action('admin_notices', 'zw_imgproxy_admin_notice');
+
+function zw_imgproxy_admin_notice()
+{
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+
+    $key = zw_get_imgproxy_setting('zw_imgproxy_key', 'IMGPROXY_KEY');
+    $salt = zw_get_imgproxy_setting('zw_imgproxy_salt', 'IMGPROXY_SALT');
+    $host = zw_get_imgproxy_setting('zw_imgproxy_url', 'IMGPROXY_URL');
+
+    $configured = (int) ($key !== '') + (int) ($salt !== '') + (int) ($host !== '');
+
+    if ($configured === 0 || $configured === 3) {
+        return;
+    }
+
+    printf(
+        '<div class="notice notice-warning"><p>%s</p></div>',
+        esc_html__('Imgproxy is gedeeltelijk geconfigureerd (key, salt en URL zijn niet alle drie ingevuld). De theme valt terug op Timber image resizing tot alle drie zijn ingesteld.', 'streekomroep')
+    );
 }
 
 /**
@@ -898,11 +935,18 @@ add_action('wp_enqueue_scripts', 'zw_add_videojs');
 
 function zw_imgproxy($src, $width, $height)
 {
-    $key = zw_get_imgproxy_setting('imgproxy_key', 'IMGPROXY_KEY');
-    $salt = zw_get_imgproxy_setting('imgproxy_salt', 'IMGPROXY_SALT');
-    $host = zw_sanitize_imgproxy_url(zw_get_imgproxy_setting('imgproxy_url', 'IMGPROXY_URL'));
+    $key = zw_get_imgproxy_setting('zw_imgproxy_key', 'IMGPROXY_KEY');
+    $salt = zw_get_imgproxy_setting('zw_imgproxy_salt', 'IMGPROXY_SALT');
+    $host = zw_sanitize_imgproxy_url(zw_get_imgproxy_setting('zw_imgproxy_url', 'IMGPROXY_URL'));
 
     if (!$host || !$key || !$salt) {
+        if ($host || $key || $salt) {
+            static $warned = false;
+            if (!$warned) {
+                error_log('zw_imgproxy: partial configuration (key/salt/url) - falling back to Timber resize.');
+                $warned = true;
+            }
+        }
         return \Timber\ImageHelper::resize($src, $width, $height);
     }
 

--- a/single.php
+++ b/single.php
@@ -216,7 +216,15 @@ if ($timber_post->post_gekoppeld_fragment) {
     /** @var Fragment $fragment */
     $fragment = Timber::get_post($timber_post->post_gekoppeld_fragment);
     if ($fragment) {
-        $context['embed'] = $fragment->getEmbed();
+        $posterUrl = null;
+        if ($timber_post->meta('post_fragment_is_featured')) {
+            $thumbnailUrl = get_the_post_thumbnail_url($timber_post->ID, 'full');
+            if ($thumbnailUrl) {
+                $posterUrl = zw_imgproxy($thumbnailUrl, 1280, 720);
+            }
+        }
+
+        $context['embed'] = $fragment->getEmbed($posterUrl);
     }
 }
 

--- a/src/Fragment.php
+++ b/src/Fragment.php
@@ -19,17 +19,18 @@ class Fragment extends Post
         return $this->_region;
     }
 
-    public function getEmbed()
+    public function getEmbed(?string $posterUrl = null)
     {
         if ($this->meta('fragment_type') === self::TYPE_VIDEO) {
             $url = $this->meta('fragment_url', ['format_value' => false]);
             if (!$url) {
                 return null;
             }
-            return VideoRenderer::renderFromUrl($url) ?: null;
+            return VideoRenderer::renderFromUrl($url, $posterUrl) ?: null;
         } elseif ($this->meta('fragment_type') === self::TYPE_AUDIO) {
             return Timber::compile('partial/player-audio-fragment.twig', [
-                'fragment' => $this
+                'fragment' => $this,
+                'poster_url' => $posterUrl,
             ]);
         }
 

--- a/src/VideoRenderer.php
+++ b/src/VideoRenderer.php
@@ -6,18 +6,24 @@ class VideoRenderer
 {
     /**
      * Render a VideoJS player for a Video object.
+     *
+     * @param Video       $video
+     * @param string|null $posterUrl Optional poster override; falls back to the Video's thumbnail when empty.
+     * @return string
      */
     public static function renderPlayer(Video $video, ?string $posterUrl = null): string
     {
-        $posterUrl = $posterUrl ?: $video->getThumbnail();
+        $posterUrl = $posterUrl ?: (string) $video->getThumbnail();
 
         $out = sprintf('<div class="not-prose" style="aspect-ratio: %f;">', $video->getAspectRatio());
         $out .= '<video class="video-js vjs-fill vjs-big-play-centered playsinline" controls';
-        $out .= ' poster="' . htmlspecialchars($posterUrl) . '"';
-        $out .= ' data-vjs-src="' . htmlspecialchars($video->getPlaylistUrl()) . '"';
+        if ($posterUrl !== '') {
+            $out .= ' poster="' . esc_url($posterUrl) . '"';
+        }
+        $out .= ' data-vjs-src="' . esc_url($video->getPlaylistUrl()) . '"';
         $out .= ' data-vjs-type="application/x-mpegURL"';
         $out .= '>';
-        $out .= '<source src="' . htmlspecialchars($video->getMP4Url()) . '" type="video/mp4">';
+        $out .= '<source src="' . esc_url($video->getMP4Url()) . '" type="video/mp4">';
         $out .= '</video>';
         $out .= '</div>';
 
@@ -53,6 +59,8 @@ class VideoRenderer
     /**
      * Fetch a video from a Bunny URL and render its player.
      *
+     * @param string      $url
+     * @param string|null $posterUrl Optional poster override forwarded to renderPlayer().
      * @return string|false Player HTML or false if unavailable
      */
     public static function renderFromUrl(string $url, ?string $posterUrl = null): string|false

--- a/src/VideoRenderer.php
+++ b/src/VideoRenderer.php
@@ -7,11 +7,13 @@ class VideoRenderer
     /**
      * Render a VideoJS player for a Video object.
      */
-    public static function renderPlayer(Video $video): string
+    public static function renderPlayer(Video $video, ?string $posterUrl = null): string
     {
+        $posterUrl = $posterUrl ?: $video->getThumbnail();
+
         $out = sprintf('<div class="not-prose" style="aspect-ratio: %f;">', $video->getAspectRatio());
         $out .= '<video class="video-js vjs-fill vjs-big-play-centered playsinline" controls';
-        $out .= ' poster="' . htmlspecialchars($video->getThumbnail()) . '"';
+        $out .= ' poster="' . htmlspecialchars($posterUrl) . '"';
         $out .= ' data-vjs-src="' . htmlspecialchars($video->getPlaylistUrl()) . '"';
         $out .= ' data-vjs-type="application/x-mpegURL"';
         $out .= '>';
@@ -53,13 +55,13 @@ class VideoRenderer
      *
      * @return string|false Player HTML or false if unavailable
      */
-    public static function renderFromUrl(string $url): string|false
+    public static function renderFromUrl(string $url, ?string $posterUrl = null): string|false
     {
         $video = self::resolveVideo($url);
         if (!$video || !$video->isAvailable()) {
             return false;
         }
 
-        return self::renderPlayer($video);
+        return self::renderPlayer($video, $posterUrl);
     }
 }

--- a/templates/partial/player-audio-fragment.twig
+++ b/templates/partial/player-audio-fragment.twig
@@ -1,7 +1,11 @@
 <div class="aspect-video ">
     <div>
+        {% set poster = poster_url|default(null) %}
+        {% if not poster and fragment.thumbnail %}
+            {% set poster = fragment.thumbnail.src|imgproxy(1280, 720) %}
+        {% endif %}
         <audio class="video-js vjs-fluid vjs-big-play-centered playsinline" data-setup="{}" autoplay
-               controls poster="{{ fragment.thumbnail.src|imgproxy(1280, 720) }}">
+               controls{% if poster %} poster="{{ poster }}"{% endif %}>
             <source src="{{ fragment.meta('fragment_url', {format_value: false}) }}" type="audio/mp3">
             Your browser does not support the audio tag.
         </audio>


### PR DESCRIPTION
## Summary
- Adds imgproxy_key, imgproxy_salt, and imgproxy_url to Settings > Media, with constants as fallback.
- Normalizes imgproxy_url with https:// and a trailing slash.
- Uses the post featured image as the VideoJS poster for highlighted linked fragments.

## Issues
Refs https://github.com/oszuidwest/site-2021-feedback/issues/128
Refs https://github.com/oszuidwest/site-2021-feedback/issues/132

## Checks
- vendor/bin/phpcs --standard=phpcs.xml .
- composer lint:twig