### PR TITLE
fix: make dossier block title override work

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -149,6 +149,8 @@ foreach ($context['options']['desking_blokken_voorpagina'] as &$block) {
                 $block['error'] = 'Er is geen dossier geselecteerd';
                 break;
             }
+            $overrideTitle = trim((string) ($block['tekst_boven_dossier'] ?? ''));
+            $block['dossier_titel'] = $overrideTitle !== '' ? $overrideTitle : $dossierTerm->name;
             $block['term'] = Timber::get_term($block['selecteer_dossier'], 'dossier');
             $block['posts'] = Timber::get_posts(
                 [

--- a/templates/blocks/blok_dossier.twig
+++ b/templates/blocks/blok_dossier.twig
@@ -17,11 +17,7 @@
                 <div class="px-4 pt-4">
                     <h1 class="font-bold">
                         <span class="rounded-md px-2 py-0.5 text-xs tracking-wide uppercase font-black font-round bg-white text-gray-800">Dossier</span>
-                        {% if block.tekst_boven_dossier %}
-                            <span class="block text-3xl my-1">{{ block.tekst_boven_dossier }}</span>
-                        {% else %}
-                            <span class="block text-3xl my-1">{{ block.term.name }}</span>
-                        {% endif %}
+                        <span class="block text-3xl my-1">{{ block.dossier_titel }}</span>
                     </h1>
                     <div class="hidden lg:block prose font-bold font-round text-gray-400 py-4">{{ block.term.description }}</div>
                 </div>


### PR DESCRIPTION
## Summary
- derive a single `dossier_titel` for the front-page dossier block
- use `tekst_boven_dossier` when filled, otherwise fall back to the selected dossier name
- simplify the Twig template to render the prepared title

Fixes oszuidwest/site-2021-feedback#24

## Behavioral note
- whitespace-only overrides now fall back to the dossier name instead of rendering blank space; the theoretical `"0"` override now renders as `"0"` instead of falling back.

## Verification
- `php -l front-page.php`
- `composer lint:twig`
- `vendor/bin/phpcs --standard=phpcs.xml .`
- `npm run build:tailwind`
- Docker/browser check on `http://localhost:8080/` with override filled and empty fallback states

## Screenshots
Captured locally during verification:
- `screenshots/issue-24/override.png`
- `screenshots/issue-24/fallback.png`