### PR TITLE
fix: load theme and video assets through wp enqueue

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -980,24 +980,13 @@ function zw_remove_wp_block_library_css()
 
 add_action('wp_enqueue_scripts', 'zw_remove_wp_block_library_css', 100);
 
-function zw_theme_asset_version(string $relative_path): string
-{
-    $path = get_theme_file_path($relative_path);
-
-    if (file_exists($path)) {
-        return (string) filemtime($path);
-    }
-
-    return (string) wp_get_theme()->get('Version');
-}
-
 function zw_enqueue_theme_assets()
 {
     wp_enqueue_style(
         'streekomroep-style',
         get_theme_file_uri('dist/style.css'),
         [],
-        zw_theme_asset_version('dist/style.css')
+        wp_get_theme()->get('Version')
     );
 }
 
@@ -1034,7 +1023,7 @@ function zw_enqueue_videojs_assets()
         'zw-videojs-init',
         get_theme_file_uri('static/videojs-init.js'),
         ['video.js', 'video.js.nl'],
-        zw_theme_asset_version('static/videojs-init.js'),
+        wp_get_theme()->get('Version'),
         true
     );
 }

--- a/functions.php
+++ b/functions.php
@@ -980,20 +980,85 @@ function zw_remove_wp_block_library_css()
 
 add_action('wp_enqueue_scripts', 'zw_remove_wp_block_library_css', 100);
 
-/**
- * Add VideoJS player
- * This function enqueues the JS and CSS for VideoJS, which is used for livestreams, on-demand video's and fragments
- */
-function zw_add_videojs()
+function zw_theme_asset_version(string $relative_path): string
 {
-    // TODO: Defer loading of Video.js CSS
-    wp_enqueue_style('video.js', 'https://cdnjs.cloudflare.com/ajax/libs/video.js/8.23.4/video-js.min.css');
-    wp_enqueue_script('video.js', 'https://cdnjs.cloudflare.com/ajax/libs/video.js/8.23.4/video.min.js', args:['strategy'  => 'defer']);
-    wp_enqueue_script('video.js.nl', 'https://cdnjs.cloudflare.com/ajax/libs/video.js/8.23.4/lang/nl.min.js', args:['strategy'  => 'defer']);
-    wp_enqueue_script('zw-videojs-init', get_stylesheet_directory_uri() . '/static/videojs-init.js', ['video.js'], filemtime(get_stylesheet_directory() . '/static/videojs-init.js'), true);
+    $path = get_theme_file_path($relative_path);
+
+    if (file_exists($path)) {
+        return (string) filemtime($path);
+    }
+
+    return (string) wp_get_theme()->get('Version');
 }
 
-add_action('wp_enqueue_scripts', 'zw_add_videojs');
+function zw_enqueue_theme_assets()
+{
+    wp_enqueue_style(
+        'streekomroep-style',
+        get_theme_file_uri('dist/style.css'),
+        [],
+        zw_theme_asset_version('dist/style.css')
+    );
+}
+
+add_action('wp_enqueue_scripts', 'zw_enqueue_theme_assets');
+
+/**
+ * Mark the current request as needing VideoJS player assets.
+ */
+function zw_require_videojs()
+{
+    $GLOBALS['zw_requires_videojs'] = true;
+}
+
+/**
+ * Add VideoJS player assets.
+ */
+function zw_enqueue_videojs_assets()
+{
+    static $videojs_enqueued = false;
+
+    if ($videojs_enqueued) {
+        return;
+    }
+
+    $videojs_enqueued = true;
+    $videojs_version = '8.23.4';
+    $videojs_base_url = 'https://cdnjs.cloudflare.com/ajax/libs/video.js/' . $videojs_version;
+
+    // TODO: Defer loading of Video.js CSS
+    wp_enqueue_style('video.js', $videojs_base_url . '/video-js.min.css', [], $videojs_version);
+    wp_enqueue_script('video.js', $videojs_base_url . '/video.min.js', [], $videojs_version, ['strategy'  => 'defer']);
+    wp_enqueue_script('video.js.nl', $videojs_base_url . '/lang/nl.min.js', ['video.js'], $videojs_version, ['strategy'  => 'defer']);
+    wp_enqueue_script(
+        'zw-videojs-init',
+        get_theme_file_uri('static/videojs-init.js'),
+        ['video.js', 'video.js.nl'],
+        zw_theme_asset_version('static/videojs-init.js'),
+        true
+    );
+}
+
+function zw_maybe_enqueue_videojs()
+{
+    $post = get_post();
+
+    if (!empty($GLOBALS['zw_requires_videojs'])) {
+        zw_enqueue_videojs_assets();
+        return;
+    }
+
+    if (is_singular() && $post instanceof WP_Post && zw_post_content_contains_videojs_embed($post)) {
+        zw_enqueue_videojs_assets();
+    }
+}
+
+add_action('wp_enqueue_scripts', 'zw_maybe_enqueue_videojs', 20);
+
+function zw_post_content_contains_videojs_embed(WP_Post $post): bool
+{
+    return preg_match('#https?://(?:iframe|player)\.mediadelivery\.net/play/[^\s<>"\']+#i', $post->post_content) === 1;
+}
 
 function zw_imgproxy($src, $width, $height)
 {

--- a/functions.php
+++ b/functions.php
@@ -993,11 +993,20 @@ function zw_enqueue_theme_assets()
 add_action('wp_enqueue_scripts', 'zw_enqueue_theme_assets');
 
 /**
- * Mark the current request as needing VideoJS player assets.
+ * Flag the current request as needing VideoJS so zw_maybe_enqueue_videojs() enqueues
+ * the player on wp_enqueue_scripts (priority 20). Call from render paths that emit a
+ * VideoJS-backed player (livestream, on-demand video, fragments) before wp_head() runs.
+ *
+ * If wp_enqueue_scripts has already fired by the time this is called, the assets are
+ * enqueued directly so a late caller still gets a working player.
  */
 function zw_require_videojs()
 {
     $GLOBALS['zw_requires_videojs'] = true;
+
+    if (did_action('wp_enqueue_scripts')) {
+        zw_enqueue_videojs_assets();
+    }
 }
 
 /**
@@ -1015,10 +1024,10 @@ function zw_enqueue_videojs_assets()
     $videojs_version = '8.23.4';
     $videojs_base_url = 'https://cdnjs.cloudflare.com/ajax/libs/video.js/' . $videojs_version;
 
-    // TODO: Defer loading of Video.js CSS
+    // TODO: Defer Video.js CSS (script is already deferred; CSS still render-blocking).
     wp_enqueue_style('video.js', $videojs_base_url . '/video-js.min.css', [], $videojs_version);
-    wp_enqueue_script('video.js', $videojs_base_url . '/video.min.js', [], $videojs_version, ['strategy'  => 'defer']);
-    wp_enqueue_script('video.js.nl', $videojs_base_url . '/lang/nl.min.js', ['video.js'], $videojs_version, ['strategy'  => 'defer']);
+    wp_enqueue_script('video.js', $videojs_base_url . '/video.min.js', [], $videojs_version, ['strategy' => 'defer']);
+    wp_enqueue_script('video.js.nl', $videojs_base_url . '/lang/nl.min.js', ['video.js'], $videojs_version, ['strategy' => 'defer']);
     wp_enqueue_script(
         'zw-videojs-init',
         get_theme_file_uri('static/videojs-init.js'),
@@ -1044,9 +1053,20 @@ function zw_maybe_enqueue_videojs()
 
 add_action('wp_enqueue_scripts', 'zw_maybe_enqueue_videojs', 20);
 
+/**
+ * Only scans raw post_content. ACF / flexible-content callers that render a player
+ * must invoke zw_require_videojs() directly.
+ */
 function zw_post_content_contains_videojs_embed(WP_Post $post): bool
 {
-    return preg_match('#https?://(?:iframe|player)\.mediadelivery\.net/play/[^\s<>"\']+#i', $post->post_content) === 1;
+    $result = preg_match('#https?://(?:iframe|player)\.mediadelivery\.net/play/[^\s<>"\']+#i', $post->post_content);
+
+    if ($result === false) {
+        error_log('zw_post_content_contains_videojs_embed: preg_match failed: ' . preg_last_error_msg());
+        return true;
+    }
+
+    return $result === 1;
 }
 
 function zw_imgproxy($src, $width, $height)

--- a/single.php
+++ b/single.php
@@ -19,9 +19,13 @@ $context = Timber::context();
 $timber_post = Timber::get_post();
 $context['post'] = $timber_post;
 
-if ($timber_post->post_type == 'fragment') {
+if ($timber_post->post_type == 'fragment' && !post_password_required($timber_post->ID)) {
     /** @var Fragment $timber_post */
     $context['posts'] = fragment_get_posts($timber_post->id);
+    $context['embed'] = $timber_post->getEmbed();
+    if ($context['embed']) {
+        zw_require_videojs();
+    }
 }
 
 $topic = $timber_post->topic();
@@ -145,6 +149,7 @@ if ($timber_post->post_type == 'tv') {
             $context['video'] = $video;
             $context['older'] = $olderVideo;
             $context['newer'] = $newerVideo;
+            zw_require_videojs();
             $context['embed'] = \Streekomroep\VideoRenderer::renderPlayer($video);
             Timber::render('single-tv-video.twig', $context);
             return;
@@ -212,7 +217,7 @@ if ($timber_post->post_type == 'fm') {
     $context['recordings'] = $recordings;
 }
 
-if ($timber_post->post_gekoppeld_fragment) {
+if (!post_password_required($timber_post->ID) && $timber_post->post_gekoppeld_fragment) {
     /** @var Fragment $fragment */
     $fragment = Timber::get_post($timber_post->post_gekoppeld_fragment);
     if ($fragment) {
@@ -225,6 +230,9 @@ if ($timber_post->post_gekoppeld_fragment) {
         }
 
         $context['embed'] = $fragment->getEmbed($posterUrl);
+        if ($context['embed']) {
+            zw_require_videojs();
+        }
     }
 }
 

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -6,7 +6,6 @@
     <meta charset="{{ site.charset }}" />
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css2?family=Nunito:wght@200;300;400;600;700;800;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ site.theme.link }}/dist/style.css?v={{ site.theme.version }}" type="text/css" media="screen" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/templates/single-fragment.twig
+++ b/templates/single-fragment.twig
@@ -3,7 +3,7 @@
 {% block content %}
     <article id="post-{{ post.id }}" class="{{ post.class }}">
         <div class="w-full mx-auto lg:max-w-960 lg:pt-12 lg:mb-12">
-            {{ post.embed }}
+            {{ embed }}
         </div>
 
         <div class="px-6 md:px-12 max-w-3xl mx-auto mt-6 pb-6">

--- a/wp-page-fm-player.php
+++ b/wp-page-fm-player.php
@@ -9,4 +9,5 @@ $schedule = new \Streekomroep\BroadcastSchedule();
 $context['current'] = $schedule->getCurrentRadioBroadcast();
 $context['next'] = $schedule->getNextRadioBroadcast();
 
+zw_require_videojs();
 Timber::render(['page-fm-player.twig', 'page.twig'], $context);

--- a/wp-page-tv-player.php
+++ b/wp-page-tv-player.php
@@ -21,4 +21,5 @@ $schedule = new BroadcastSchedule();
 $today = $schedule->getToday();
 $context['tv_today'] = $today->television;
 
+zw_require_videojs();
 Timber::render(['page-tv-player.twig', 'page.twig'], $context);


### PR DESCRIPTION
## Summary
- enqueue `dist/style.css` through WordPress instead of hard-coding it in the Twig header
- use the theme `Version` header as the cache-busting version for internal theme assets
- centralize VideoJS asset registration and load it only when the request needs a player
- mark known player templates/routes explicitly and keep a lightweight content scan for Bunny/MediaDelivery embeds that are discovered through post content

## Verification
- `vendor/bin/phpcs --standard=phpcs.xml .`
- `composer lint:twig`
- `npm run build:tailwind`
- `git diff --check`
- Docker smoke test on `http://localhost:8080`:
  - normal page includes `streekomroep-style-css?ver=1.15.2` and no VideoJS assets
  - TV player page includes `streekomroep-style-css?ver=1.15.2`, VideoJS CSS/JS, Dutch lang file, and `zw-videojs-init?ver=1.15.2`

## Notes
- VideoJS remains pinned to `8.23.4`, which is the newest version available on cdnjs. npm currently exposes newer 8.x tags, but those versions are not available at the current cdnjs URL pattern.
