### PR TITLE
chore: update local development tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
-# Copy this file to .env and fill in your values
-ACF_PRO_LICENSE=
+# No local environment variables are required by default.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,19 +28,13 @@ jobs:
       - name: Set-up Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 'lts/*'
 
       - name: Install Node dependencies
-        run: |
-          npm install
-          npx browserslist@latest --update-db
+        run: npm install
 
       - name: Build CSS
-        run: |
-          npx @tailwindcss/cli -i assets/style.css -o dist/style.css --minify
-          npx @tailwindcss/cli -i assets/editor.css -o dist/editor.css --minify
-        env:
-          NODE_ENV: production
+        run: npm run build:tailwind
 
       - name: Deploy to remote server
         if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,16 +60,14 @@ jobs:
         if: env.RELEASE_NEEDED == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 'lts/*'
 
       - name: Install dependencies
         if: env.RELEASE_NEEDED == 'true'
         run: |
           composer install --no-dev --optimize-autoloader
           npm install
-          npx browserslist@latest --update-db
-          npx @tailwindcss/cli -i assets/style.css -o dist/style.css --minify
-          npx @tailwindcss/cli -i assets/editor.css -o dist/editor.css --minify
+          npm run build:tailwind
 
       - name: Tag and release if needed
         if: env.RELEASE_NEEDED == 'true'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,9 +14,9 @@ This is a WordPress theme with some hard dependencies. You can't run it without 
 ## Hard dependencies
 Install these before activating the theme:
 - Timber 2.4.1: Bundled via Composer, no separate installation needed
-- Advanced Custom Fields Pro 6.3.x: [[purchase](https://www.advancedcustomfields.com/pro/)]
+- Secure Custom Fields 6.8.x or Advanced Custom Fields Pro 6.x: Docker uses [Secure Custom Fields](https://wordpress.org/plugins/secure-custom-fields/) for development; licensed environments may use [ACF Pro](https://www.advancedcustomfields.com/pro/).
 - Classic Editor 1.x: [[free download](https://wordpress.org/plugins/classic-editor/)] _(we are giving the block editor more time to stabilize)_
-- Yoast SEO Premium 24.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]
+- Yoast SEO Premium 27.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]
 
 ## Soft dependencies
 These are tested plugins and are great additions to the theme:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Instructions for macOS:
 
 ```bash
 npm install
-npx browserslist@latest --update-db
-NODE_ENV=production npx tailwindcss build assets/style.css -o dist/style.css --minify
+npm run build:tailwind
 composer install --prefer-dist --no-dev --optimize-autoloader
 ```
 - Upload the theme to `/wp-content/themes/` and activate it.
@@ -26,7 +25,7 @@ composer install --prefer-dist --no-dev --optimize-autoloader
 For Linux users, use `apt` or `yum` instead of Homebrew. This theme has not been tested on Windows, but should work if your Composer and Node versions are up-to-date. To build remotely, consider using GitHub Actions or [Buddy CI/CD](https://buddy.works/) for the building and uploading process.
 
 ## Local development with Docker
-A Docker setup is included for local development. It provides WordPress with the theme mounted, a MariaDB database, and phpMyAdmin.
+A Docker setup is included for local development. It provides WordPress on PHP 8.3 with the theme mounted, MariaDB LTS, phpMyAdmin, and Secure Custom Fields for development.
 
 ```bash
 docker compose up -d
@@ -44,9 +43,9 @@ To reset: `docker compose down -v` (removes database)
 ### Hard dependencies
 Install these before activating the theme:
 - Timber 2.4.1: [Bundled; if you build yourself, use composer](https://timber.github.io/docs/v2/installation/installation/)
-- Advanced Custom Fields Pro 6.3.x: [[purchase](https://www.advancedcustomfields.com/pro/)]
+- Secure Custom Fields 6.8.x or Advanced Custom Fields Pro 6.x: Docker uses [Secure Custom Fields](https://wordpress.org/plugins/secure-custom-fields/) for development; licensed environments may use [ACF Pro](https://www.advancedcustomfields.com/pro/).
 - Classic Editor 1.x: [[free download](https://wordpress.org/plugins/classic-editor/)] _(we are giving the block editor more time to stabilize)_
-- Yoast SEO Premium 24.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]
+- Yoast SEO Premium 27.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]
 
 ### Soft dependencies
 These tested plugins enhance the theme:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DEBUG: 1
-      ACF_PRO_LICENSE: ${ACF_PRO_LICENSE:-}
     volumes:
       - wordpress_data:/var/www/html
       - ./:/var/www/html/wp-content/themes/streekomroep
@@ -23,13 +22,14 @@ services:
     restart: unless-stopped
 
   db:
-    image: mariadb:10.11
+    image: mariadb:lts
     container_name: streekomroep-db
     environment:
-      MYSQL_DATABASE: wordpress
-      MYSQL_USER: wordpress
-      MYSQL_PASSWORD: wordpress
-      MYSQL_ROOT_PASSWORD: rootpassword
+      MARIADB_DATABASE: wordpress
+      MARIADB_USER: wordpress
+      MARIADB_PASSWORD: wordpress
+      MARIADB_ROOT_PASSWORD: rootpassword
+      MARIADB_AUTO_UPGRADE: 1
     volumes:
       - db_data:/var/lib/mysql
     healthcheck:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM wordpress:6.9.1-php8.3-apache
+FROM composer:latest AS composer
+FROM node:lts-slim AS node
+FROM wordpress:6.9.4-php8.3-apache
 
 # Install WP-CLI
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
@@ -7,9 +9,9 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 
 # Install unzip for plugin installation, acl for default permissions, and Composer
 RUN apt-get update && apt-get install -y unzip acl && rm -rf /var/lib/apt/lists/*
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
-COPY --from=node:24-slim /usr/local/bin/node /usr/local/bin/node
-COPY --from=node:24-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,11 +21,29 @@ set -e
     npm install --prefix "$THEME_DIR"
     npm run build:tailwind --prefix "$THEME_DIR"
 
+    install_secure_custom_fields() {
+        echo "Installing/updating Secure Custom Fields latest stable..."
+        for plugin in advanced-custom-fields advanced-custom-fields-pro; do
+            if wp plugin is-installed "$plugin" --allow-root 2>/dev/null; then
+                wp plugin deactivate "$plugin" --allow-root || true
+                wp plugin delete "$plugin" --allow-root || echo "Failed to remove legacy plugin $plugin"
+            fi
+        done
+
+        wp plugin install secure-custom-fields --force --activate --allow-root || echo "Failed to install Secure Custom Fields"
+        SCF_INSTALLED_VERSION=$(wp plugin get secure-custom-fields --field=version --allow-root 2>/dev/null || true)
+        if [ -n "$SCF_INSTALLED_VERSION" ]; then
+            echo "Secure Custom Fields ${SCF_INSTALLED_VERSION} installed."
+        fi
+    }
+
     # Wait for database
     sleep 3
 
     # Install WordPress if not already installed
+    WORDPRESS_WAS_INSTALLED=1
     if ! wp core is-installed --allow-root 2>/dev/null; then
+        WORDPRESS_WAS_INSTALLED=0
         echo "Installing WordPress..."
         wp core install \
             --url="http://localhost:8080" \
@@ -38,22 +56,15 @@ set -e
             --allow-root
 
         # Install plugins before language pack to avoid WP-CLI locale conflicts
-        echo "Installing Yoast SEO Premium..."
-        wp plugin install "https://yoast.com/app/uploads/2026/02/wordpress-seo-premium-26.9.zip" --activate --allow-root || echo "Failed to install Yoast SEO Premium"
+        YOAST_SEO_VERSION="27.6"
+        echo "Installing Yoast SEO ${YOAST_SEO_VERSION}..."
+        wp plugin install wordpress-seo --version="$YOAST_SEO_VERSION" --activate --allow-root || echo "Failed to install Yoast SEO"
 
-        # Install ACF Pro if license key is provided
-        if [ -n "$ACF_PRO_LICENSE" ]; then
-            echo "Installing Advanced Custom Fields Pro..."
-            ACF_URL="https://connect.advancedcustomfields.com/v2/plugins/download?p=pro&k=${ACF_PRO_LICENSE}"
-            if curl -fSLo /tmp/acf-pro.zip "$ACF_URL"; then
-                wp plugin install /tmp/acf-pro.zip --activate --allow-root || echo "Failed to install ACF Pro"
-                rm -f /tmp/acf-pro.zip
-            else
-                echo "Failed to download ACF Pro (check your license key)"
-            fi
-        else
-            echo "Skipping ACF Pro (no ACF_PRO_LICENSE set)"
-        fi
+        echo "Installing Yoast SEO Premium ${YOAST_SEO_VERSION}..."
+        wp plugin install "https://yoast.com/app/uploads/2026/05/wordpress-seo-premium-${YOAST_SEO_VERSION}.zip" --activate --allow-root || echo "Failed to install Yoast SEO Premium"
+
+        # Secure Custom Fields provides the ACF-compatible APIs required by the theme.
+        install_secure_custom_fields
 
         echo "Installing Classic Editor..."
         wp plugin install classic-editor --activate --allow-root
@@ -136,6 +147,10 @@ set -e
         wp menu item add-custom Footer "West-Brabant" "http://localhost:8080/regio/west-brabant/" --parent-id=$NIEUWS --allow-root
 
         echo "WordPress installed successfully!"
+    fi
+
+    if [ "$WORDPRESS_WAS_INSTALLED" -eq 1 ]; then
+        install_secure_custom_fields
     fi
 
     # Fix permissions AFTER installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "license": "ISC",
       "dependencies": {
         "@tailwindcss/cli": "^4.3.0",
-        "@tailwindcss/typography": "^0.5.16",
-        "tailwindcss": "^4.1.0"
+        "@tailwindcss/typography": "^0.5.19",
+        "tailwindcss": "^4.3.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@tailwindcss/cli": "^4.3.0",
-    "@tailwindcss/typography": "^0.5.16",
-    "tailwindcss": "^4.1.0"
+    "@tailwindcss/typography": "^0.5.19",
+    "tailwindcss": "^4.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- update the local Docker stack to PHP 8.3, MariaDB LTS, Composer latest, Node LTS, and phpMyAdmin latest
- use Secure Custom Fields for local development while documenting that licensed environments may still use ACF Pro
- simplify Tailwind builds to use npm run build:tailwind in docs, Docker, and GitHub Actions

## Verification
- bash -n docker/entrypoint.sh
- docker compose config
- docker compose up -d --build --force-recreate --no-deps wordpress
- WP-CLI plugin/API checks for Secure Custom Fields and ACF-compatible functions
- curl -I http://localhost:8080
- git diff --check