### PR TITLE
fix: resolve primary regio consistently

### DIFF
--- a/src/Fragment.php
+++ b/src/Fragment.php
@@ -8,16 +8,6 @@ class Fragment extends Post
 {
     public const TYPE_VIDEO = 'Video';
     public const TYPE_AUDIO = 'Audio';
-    public function region()
-    {
-        if (!$this->_region) {
-            $regions = $this->terms(['query' => ['taxonomy' => 'regio']]);
-            if (is_array($regions) && count($regions)) {
-                $this->_region = $regions[0];
-            }
-        }
-        return $this->_region;
-    }
 
     public function getEmbed(?string $posterUrl = null)
     {

--- a/src/Post.php
+++ b/src/Post.php
@@ -11,13 +11,25 @@ class Post extends \Timber\Post
 
     public function region()
     {
+        return $this->resolveRegion();
+    }
+
+    protected function resolveRegion()
+    {
         if ($this->_region === null) {
             $id = yoast_get_primary_term_id('regio', $this->ID);
             if ($id) {
                 $this->_region = Timber::get_term($id, 'regio');
-            } else {
-                $this->_region = false;
+                return $this->_region;
             }
+
+            $regions = $this->terms(['query' => ['taxonomy' => 'regio']]);
+            if (is_array($regions) && count($regions)) {
+                $this->_region = $regions[0];
+                return $this->_region;
+            }
+
+            $this->_region = false;
         }
         return $this->_region;
     }

--- a/templates/partial/tag-region.twig
+++ b/templates/partial/tag-region.twig
@@ -1,9 +1,11 @@
 <div class="flex">
-<span class="rounded-md px-2 py-0.5 text-xs tracking-wide uppercase font-black font-round bg-groen text-white">
    {% if region %}
-       {{- region.title -}}
+       <a href="{{ region.link }}" class="rounded-md px-2 py-0.5 text-xs tracking-wide uppercase font-black font-round bg-groen text-white">
+           {{- region.title -}}
+       </a>
    {% else %}
-       {{- options.placeholder_geen_regio -}}
+       <span class="rounded-md px-2 py-0.5 text-xs tracking-wide uppercase font-black font-round bg-groen text-white">
+           {{- options.placeholder_geen_regio -}}
+       </span>
    {% endif %}
-</span>
 </div>

--- a/templates/single-fragment.twig
+++ b/templates/single-fragment.twig
@@ -14,9 +14,7 @@
                     <span class="rounded-md px-2 py-0.5 text-xs tracking-wide uppercase font-black font-round bg-roze text-white">Audio</span>
                 {% endif %}
 
-                {% if post.region %}
-                    <span class="rounded-md px-2 py-0.5 text-xs tracking-wide uppercase font-black font-round bg-groen text-white">{{ post.region.title }}</span>
-                {% endif %}
+                {{ include('partial/tag-region.twig', {region: post.region}) }}
             </div>
             <h1 class="text-4xl lg:text-5xl font-black font-round my-2 break-words text-black dark:text-white">{{ post.title }}</h1>
             <time class="text-xs tracking-wide uppercase font-black font-round text-black dark:text-gray-200"


### PR DESCRIPTION
## Summary
- resolve regio for posts and fragments through one shared path
- primary regio wins when set
- without a primary regio, use the first assigned regio term
- without assigned regio terms, show the shared ACF `placeholder_geen_regio` fallback
- link visible regio tags to their regio archive pages

## Local Docker verification
Started the provided Docker stack at http://localhost:8080 and created a 10-case matrix for both `fragment` and `post`:

| Case | Expected |
| --- | --- |
| Fragment, no regio | placeholder `Regio` |
| Fragment, one regio, no primary | `Roosendaal` |
| Fragment, one regio, primary | `Roosendaal` |
| Fragment, multiple regio, no primary | first term `Bergen op Zoom` |
| Fragment, multiple regio, primary Roosendaal | `Roosendaal` |
| Article, no regio | placeholder `Regio` |
| Article, one regio, no primary | `Roosendaal` |
| Article, one regio, primary | `Roosendaal` |
| Article, multiple regio, no primary | first term `Bergen op Zoom` |
| Article, multiple regio, primary Roosendaal | `Roosendaal` |

Screenshots were generated locally in `screenshots/issue-127/`, including both regio archive targets.

## Checks
- php -l src/Post.php && php -l src/Fragment.php
- vendor/bin/phpcs --standard=phpcs.xml src/Post.php src/Fragment.php
- vendor/bin/phpcs --standard=phpcs.xml .
- composer lint:twig

Fixes oszuidwest/site-2021-feedback#127