### PR TITLE
fix: preserve FM recording times

### DIFF
--- a/single.php
+++ b/single.php
@@ -175,7 +175,8 @@ if ($timber_post->post_type == 'fm') {
 
 
                 if (($hour->isAfter($ruleStart) || $hour->is($ruleStart)) && $hour->isBefore($ruleEnd)) {
-                    $recordings[] = $hour;
+                    // Store a copy because the loop cursor is a mutable Carbon instance.
+                    $recordings[] = $hour->copy();
                 }
             }
 

--- a/style.css
+++ b/style.css
@@ -2,5 +2,5 @@
  * Theme Name: Streekomroep
  * Description: This is a WordPress theme made for Streekomroep ZuidWest in the Netherlands. It's made using Timber and Tailwind CSS and provides functionality for regional news, radio and television broadcasts.
  * Author: Streekomroep ZuidWest
- * Version: 1.16.2
+ * Version: 1.16.3
 */


### PR DESCRIPTION
## Summary
- Store a copy of the FM gemist loop cursor before adding it to recordings
- Prevent mutable Carbon updates from shifting all listed recordings to the final iterated hour

## Tests
- vendor/bin/phpcs --standard=phpcs.xml single.php
- git diff --check