### PR TITLE
chore: align Timber maintenance details

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ This is a WordPress theme with some hard dependencies. You can't run it without 
 
 ## Hard dependencies
 Install these before activating the theme:
-- Timber 2.4.1: Bundled via Composer, no separate installation needed
+- Timber 2.5.1: Bundled via Composer, no separate installation needed
 - Secure Custom Fields 6.8.x or Advanced Custom Fields Pro 6.x: Docker uses [Secure Custom Fields](https://wordpress.org/plugins/secure-custom-fields/) for development; licensed environments may use [ACF Pro](https://www.advancedcustomfields.com/pro/).
 - Classic Editor 1.x: [[free download](https://wordpress.org/plugins/classic-editor/)] _(we are giving the block editor more time to stabilize)_
 - Yoast SEO Premium 27.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To reset: `docker compose down -v` (removes database)
 
 ### Hard dependencies
 Install these before activating the theme:
-- Timber 2.4.1: [Bundled; if you build yourself, use composer](https://timber.github.io/docs/v2/installation/installation/)
+- Timber 2.5.1: [Bundled; if you build yourself, use composer](https://timber.github.io/docs/v2/installation/installation/)
 - Secure Custom Fields 6.8.x or Advanced Custom Fields Pro 6.x: Docker uses [Secure Custom Fields](https://wordpress.org/plugins/secure-custom-fields/) for development; licensed environments may use [ACF Pro](https://www.advancedcustomfields.com/pro/).
 - Classic Editor 1.x: [[free download](https://wordpress.org/plugins/classic-editor/)] _(we are giving the block editor more time to stabilize)_
 - Yoast SEO Premium 27.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]

--- a/src/BroadcastSchedule.php
+++ b/src/BroadcastSchedule.php
@@ -5,7 +5,7 @@ namespace Streekomroep;
 use Carbon\Carbon;
 use DateTime;
 use DateTimeImmutable;
-use Timber;
+use Timber\Timber;
 
 class BroadcastSchedule
 {
@@ -51,7 +51,7 @@ class BroadcastSchedule
                     }
 
                     if ($entry['show'] instanceof \WP_Post) {
-                        $entry['show'] = Timber\Timber::get_post($entry['show']->ID);
+                        $entry['show'] = Timber::get_post($entry['show']->ID);
                     }
 
                     $day->addTelevision(new TelevisionBroadcast($entry['show'], $entry['naam_override'], $entry['starttijden']));

--- a/src/Gallery.php
+++ b/src/Gallery.php
@@ -2,7 +2,7 @@
 
 namespace Streekomroep;
 
-use Timber\Image;
+use Timber\ImageInterface;
 use Timber\Timber;
 use WP_Post;
 
@@ -232,7 +232,7 @@ class Gallery
     {
         $image = Timber::get_image($attachment);
 
-        if (!$image instanceof Image) {
+        if (!$image instanceof ImageInterface) {
             return null;
         }
 


### PR DESCRIPTION
## Summary
- use the explicit `Timber\Timber` import in `BroadcastSchedule`
- check gallery images against `Timber\ImageInterface` instead of the concrete image class
- update Timber dependency documentation from 2.4.1 to 2.5.1

## Verification
- `composer install`
- `vendor/bin/phpcs --standard=phpcs.xml .`
- `composer lint:twig`
- `composer validate --strict` *(fails on existing missing `license` warning in composer.json)*