### PR TITLE
fix: add responsive srcsets for content images

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -70,7 +70,7 @@
     margin: 0;
 }
 
-/* Grid stories layout */
+/* Grid stories layout. Keep column fractions in sync with templates/blocks/blok_top_stories.twig sizes. */
 .grid-stories {
     @apply grid-cols-2;
 }

--- a/src/Gallery.php
+++ b/src/Gallery.php
@@ -254,7 +254,7 @@ class Gallery
         return [
             'class' => self::getImageClasses($attributes['type']),
             'src' => $src,
-            'srcset' => self::buildImageSrcset($width, $height),
+            'srcset' => ResponsiveImage::srcset($src, $width, $height),
             'sizes' => $layout['sizes'],
             'alt' => $alt,
             'width' => $width,
@@ -262,39 +262,6 @@ class Gallery
             'loading' => 'lazy',
             'decoding' => 'async',
         ];
-    }
-
-    private static function buildImageSrcset(int $width, int $height): array
-    {
-        $srcset = [];
-
-        foreach (self::getSrcsetWidths($width) as $srcsetWidth) {
-            $srcsetHeight = (int) round($srcsetWidth / $width * $height);
-            $srcset[] = [
-                'width' => $srcsetWidth,
-                'height' => $srcsetHeight,
-                'descriptor' => $srcsetWidth . 'w',
-            ];
-        }
-
-        return $srcset;
-    }
-
-    /**
-     * @return int[]
-     */
-    private static function getSrcsetWidths(int $width): array
-    {
-        $widths = [
-            max(192, (int) round($width / 2)),
-            $width,
-            $width * 2,
-        ];
-
-        $widths = array_values(array_unique(array_filter($widths)));
-        sort($widths);
-
-        return $widths;
     }
 
     private static function getGalleryClasses(array $attributes): string

--- a/src/Gallery.php
+++ b/src/Gallery.php
@@ -254,13 +254,10 @@ class Gallery
         return [
             'class' => self::getImageClasses($attributes['type']),
             'src' => $src,
-            'srcset' => ResponsiveImage::srcset($src, $width, $height),
             'sizes' => $layout['sizes'],
             'alt' => $alt,
             'width' => $width,
             'height' => $height,
-            'loading' => 'lazy',
-            'decoding' => 'async',
         ];
     }
 

--- a/src/ResponsiveImage.php
+++ b/src/ResponsiveImage.php
@@ -4,10 +4,24 @@ namespace Streekomroep;
 
 final class ResponsiveImage
 {
+    /**
+     * Build imgproxy srcset candidates for the largest 1x CSS-pixel slot in the sizes attribute.
+     *
+     * @param \Timber\ImageInterface|string|null $src Image source accepted by zw_imgproxy().
+     */
     public static function srcset($src, int $width, int $height): string
     {
         if ($width <= 0 || $height <= 0) {
-            self::logInvalidDimensions($src, $width, $height);
+            \wp_trigger_error(
+                __METHOD__,
+                sprintf(
+                    'Invalid image dimensions (%dx%d) for source type %s; omitting srcset.',
+                    $width,
+                    $height,
+                    get_debug_type($src)
+                ),
+                \E_USER_WARNING
+            );
             return '';
         }
 
@@ -26,24 +40,5 @@ final class ResponsiveImage
         }
 
         return implode(', ', $srcset);
-    }
-
-    private static function logInvalidDimensions($src, int $width, int $height): void
-    {
-        static $warned = [];
-
-        $type = get_debug_type($src);
-        $key = $type . ':' . $width . 'x' . $height;
-        if (isset($warned[$key])) {
-            return;
-        }
-
-        $warned[$key] = true;
-        error_log(sprintf(
-            'responsive_image_srcset: invalid image dimensions (%dx%d) for source type %s; omitting srcset.',
-            $width,
-            $height,
-            $type
-        ));
     }
 }

--- a/src/ResponsiveImage.php
+++ b/src/ResponsiveImage.php
@@ -4,65 +4,26 @@ namespace Streekomroep;
 
 final class ResponsiveImage
 {
-    public static function srcset($src, $width, $height): string
+    public static function srcset($src, int $width, int $height): string
     {
-        $width = self::normalizeDimension($width);
-        $height = self::normalizeDimension($height);
-
         if ($width <= 0 || $height <= 0) {
             return '';
         }
 
-        $srcset = [];
-        foreach (self::dimensions($width, $height) as $candidate) {
-            $srcset[] = sprintf(
-                '%s %s',
-                \zw_imgproxy($src, $candidate['width'], $candidate['height']),
-                $candidate['descriptor']
-            );
-        }
-
-        return implode(', ', $srcset);
-    }
-
-    /**
-     * @return array<int, array{width: int, height: int, descriptor: string}>
-     */
-    public static function dimensions(int $width, int $height): array
-    {
-        $srcset = [];
-
-        foreach (self::widths($width) as $srcsetWidth) {
-            $srcsetHeight = (int) round($srcsetWidth / $width * $height);
-            $srcset[] = [
-                'width' => $srcsetWidth,
-                'height' => $srcsetHeight,
-                'descriptor' => $srcsetWidth . 'w',
-            ];
-        }
-
-        return $srcset;
-    }
-
-    /**
-     * @return int[]
-     */
-    public static function widths(int $width): array
-    {
         $widths = [
             max(192, (int) round($width / 2)),
             $width,
             $width * 2,
         ];
-
-        $widths = array_values(array_unique(array_filter($widths)));
+        $widths = array_values(array_unique($widths));
         sort($widths);
 
-        return $widths;
-    }
+        $srcset = [];
+        foreach ($widths as $srcsetWidth) {
+            $srcsetHeight = (int) round($srcsetWidth / $width * $height);
+            $srcset[] = \zw_imgproxy($src, $srcsetWidth, $srcsetHeight) . ' ' . $srcsetWidth . 'w';
+        }
 
-    private static function normalizeDimension($dimension): int
-    {
-        return max(0, (int) round((float) $dimension));
+        return implode(', ', $srcset);
     }
 }

--- a/src/ResponsiveImage.php
+++ b/src/ResponsiveImage.php
@@ -7,6 +7,7 @@ final class ResponsiveImage
     public static function srcset($src, int $width, int $height): string
     {
         if ($width <= 0 || $height <= 0) {
+            self::logInvalidDimensions($src, $width, $height);
             return '';
         }
 
@@ -15,7 +16,7 @@ final class ResponsiveImage
             $width,
             $width * 2,
         ];
-        $widths = array_values(array_unique($widths));
+        $widths = array_unique($widths);
         sort($widths);
 
         $srcset = [];
@@ -25,5 +26,24 @@ final class ResponsiveImage
         }
 
         return implode(', ', $srcset);
+    }
+
+    private static function logInvalidDimensions($src, int $width, int $height): void
+    {
+        static $warned = [];
+
+        $type = get_debug_type($src);
+        $key = $type . ':' . $width . 'x' . $height;
+        if (isset($warned[$key])) {
+            return;
+        }
+
+        $warned[$key] = true;
+        error_log(sprintf(
+            'responsive_image_srcset: invalid image dimensions (%dx%d) for source type %s; omitting srcset.',
+            $width,
+            $height,
+            $type
+        ));
     }
 }

--- a/src/ResponsiveImage.php
+++ b/src/ResponsiveImage.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Streekomroep;
+
+final class ResponsiveImage
+{
+    public static function srcset($src, $width, $height): string
+    {
+        $width = self::normalizeDimension($width);
+        $height = self::normalizeDimension($height);
+
+        if ($width <= 0 || $height <= 0) {
+            return '';
+        }
+
+        $srcset = [];
+        foreach (self::dimensions($width, $height) as $candidate) {
+            $srcset[] = sprintf(
+                '%s %s',
+                \zw_imgproxy($src, $candidate['width'], $candidate['height']),
+                $candidate['descriptor']
+            );
+        }
+
+        return implode(', ', $srcset);
+    }
+
+    /**
+     * @return array<int, array{width: int, height: int, descriptor: string}>
+     */
+    public static function dimensions(int $width, int $height): array
+    {
+        $srcset = [];
+
+        foreach (self::widths($width) as $srcsetWidth) {
+            $srcsetHeight = (int) round($srcsetWidth / $width * $height);
+            $srcset[] = [
+                'width' => $srcsetWidth,
+                'height' => $srcsetHeight,
+                'descriptor' => $srcsetWidth . 'w',
+            ];
+        }
+
+        return $srcset;
+    }
+
+    /**
+     * @return int[]
+     */
+    public static function widths(int $width): array
+    {
+        $widths = [
+            max(192, (int) round($width / 2)),
+            $width,
+            $width * 2,
+        ];
+
+        $widths = array_values(array_unique(array_filter($widths)));
+        sort($widths);
+
+        return $widths;
+    }
+
+    private static function normalizeDimension($dimension): int
+    {
+        return max(0, (int) round((float) $dimension));
+    }
+}

--- a/src/ResponsiveImage.php
+++ b/src/ResponsiveImage.php
@@ -11,17 +11,8 @@ final class ResponsiveImage
      */
     public static function srcset($src, int $width, int $height): string
     {
+        // Dimensions are validated by the calling macro in responsive-image.twig.
         if ($width <= 0 || $height <= 0) {
-            \wp_trigger_error(
-                __METHOD__,
-                sprintf(
-                    'Invalid image dimensions (%dx%d) for source type %s; omitting srcset.',
-                    $width,
-                    $height,
-                    get_debug_type($src)
-                ),
-                \E_USER_WARNING
-            );
             return '';
         }
 

--- a/src/Site.php
+++ b/src/Site.php
@@ -166,6 +166,7 @@ class Site extends \Timber\Site
 
         $twig->addFilter(new \Twig\TwigFilter('format_schedule', [$this, 'format_schedule']));
         $twig->addFunction(new \Twig\TwigFunction('icon', [$this, 'get_icon']));
+        $twig->addFunction(new \Twig\TwigFunction('responsive_image_srcset', [ResponsiveImage::class, 'srcset']));
         $twig->addFilter(new \Twig\TwigFilter('imgproxy', [$this, 'imgproxy']));
         return $twig;
     }

--- a/src/Video.php
+++ b/src/Video.php
@@ -41,9 +41,14 @@ class Video
         return $this->data->guid;
     }
 
-    public function getThumbnail()
+    public function getThumbnail(): ?string
     {
-        return $this->credentials->hostname . '/' . $this->data->guid . '/' . $this->data->thumbnailFileName;
+        $thumbnailFileName = trim((string) ($this->data->thumbnailFileName ?? ''));
+        if ($thumbnailFileName === '') {
+            return null;
+        }
+
+        return $this->credentials->hostname . '/' . $this->data->guid . '/' . $thumbnailFileName;
     }
 
     public function getName()

--- a/src/VideoSeo.php
+++ b/src/VideoSeo.php
@@ -91,8 +91,8 @@ class VideoSeo
             return $video->getDescription();
         };
 
-        $thumbnail = function () use ($video) {
-            return $video->getThumbnail() ?: '';
+        $thumbnail = function ($image) use ($video) {
+            return $video->getThumbnail() ?: $image;
         };
 
         add_filter('wpseo_title', $title);
@@ -105,9 +105,14 @@ class VideoSeo
             return 'video.episode';
         });
         add_action('wpseo_add_opengraph_images', function ($images) use ($video) {
-            $thumbnailUrl = \zw_normalize_imgproxy_src($video->getThumbnail());
+            $thumbnail = $video->getThumbnail();
+            if ($thumbnail === null) {
+                return;
+            }
+
+            $thumbnailUrl = \zw_normalize_imgproxy_src($thumbnail);
             if ($thumbnailUrl === null) {
-                \zw_log_invalid_imgproxy_src($video->getThumbnail(), 'skipping Open Graph video image');
+                \zw_log_invalid_imgproxy_src($thumbnail, 'skipping Open Graph video image');
                 return;
             }
 
@@ -143,7 +148,11 @@ class VideoSeo
             return $presenters;
         });
 
-        add_filter('wpseo_frontend_presentation', function ($presentation, $context) {
+        add_filter('wpseo_frontend_presentation', function ($presentation, $context) use ($video) {
+            if ($video->getThumbnail() === null) {
+                return $presentation;
+            }
+
             $presentation->model->open_graph_image_id = null;
             $presentation->model->open_graph_image_meta = null;
             $presentation->model->open_graph_image = null;

--- a/src/VideoSeo.php
+++ b/src/VideoSeo.php
@@ -152,7 +152,7 @@ class VideoSeo
             return $presenters;
         });
 
-        add_filter('wpseo_frontend_presentation', function ($presentation, $context) use ($socialImageUrl) {
+        add_filter('wpseo_frontend_presentation', function ($presentation) use ($socialImageUrl) {
             if ($socialImageUrl === null) {
                 return $presentation;
             }
@@ -161,6 +161,6 @@ class VideoSeo
             $presentation->model->open_graph_image_meta = null;
             $presentation->model->open_graph_image = null;
             return $presentation;
-        }, 10, 2);
+        });
     }
 }

--- a/src/VideoSeo.php
+++ b/src/VideoSeo.php
@@ -92,7 +92,18 @@ class VideoSeo
         };
 
         $thumbnail = function ($image) use ($video) {
-            return $video->getThumbnail() ?: $image;
+            $thumbnail = $video->getThumbnail();
+            if ($thumbnail === null) {
+                return $image;
+            }
+
+            $thumbnailUrl = \zw_normalize_imgproxy_src($thumbnail);
+            if ($thumbnailUrl === null) {
+                \zw_log_invalid_imgproxy_src($thumbnail, 'keeping default Twitter video image');
+                return $image;
+            }
+
+            return zw_imgproxy($thumbnailUrl, self::OG_IMAGE_WIDTH, self::OG_IMAGE_HEIGHT);
         };
 
         add_filter('wpseo_title', $title);

--- a/src/VideoSeo.php
+++ b/src/VideoSeo.php
@@ -92,7 +92,7 @@ class VideoSeo
         };
 
         $thumbnail = function () use ($video) {
-            return $video->getThumbnail();
+            return $video->getThumbnail() ?: '';
         };
 
         add_filter('wpseo_title', $title);

--- a/src/VideoSeo.php
+++ b/src/VideoSeo.php
@@ -91,20 +91,18 @@ class VideoSeo
             return $video->getDescription();
         };
 
-        $thumbnail = function ($image) use ($video) {
-            $thumbnail = $video->getThumbnail();
-            if ($thumbnail === null) {
-                return $image;
-            }
-
+        // Resolve the social image once; all image-related hooks below must share this
+        // value so the default Yoast image is only replaced when a valid one exists.
+        $socialImageUrl = null;
+        $thumbnail = $video->getThumbnail();
+        if ($thumbnail !== null) {
             $thumbnailUrl = \zw_normalize_imgproxy_src($thumbnail);
             if ($thumbnailUrl === null) {
-                \zw_log_invalid_imgproxy_src($thumbnail, 'keeping default Twitter video image');
-                return $image;
+                \zw_log_invalid_imgproxy_src($thumbnail, 'keeping default social images');
+            } else {
+                $socialImageUrl = zw_imgproxy($thumbnailUrl, self::OG_IMAGE_WIDTH, self::OG_IMAGE_HEIGHT);
             }
-
-            return zw_imgproxy($thumbnailUrl, self::OG_IMAGE_WIDTH, self::OG_IMAGE_HEIGHT);
-        };
+        }
 
         add_filter('wpseo_title', $title);
         add_filter('wpseo_metadesc', $description);
@@ -115,20 +113,13 @@ class VideoSeo
         add_filter('wpseo_opengraph_type', function () {
             return 'video.episode';
         });
-        add_action('wpseo_add_opengraph_images', function ($images) use ($video) {
-            $thumbnail = $video->getThumbnail();
-            if ($thumbnail === null) {
-                return;
-            }
-
-            $thumbnailUrl = \zw_normalize_imgproxy_src($thumbnail);
-            if ($thumbnailUrl === null) {
-                \zw_log_invalid_imgproxy_src($thumbnail, 'skipping Open Graph video image');
+        add_action('wpseo_add_opengraph_images', function ($images) use ($socialImageUrl) {
+            if ($socialImageUrl === null) {
                 return;
             }
 
             $images->add_image([
-                'url' => zw_imgproxy($thumbnailUrl, self::OG_IMAGE_WIDTH, self::OG_IMAGE_HEIGHT),
+                'url' => $socialImageUrl,
                 'width' => self::OG_IMAGE_WIDTH,
                 'height' => self::OG_IMAGE_HEIGHT,
             ]);
@@ -137,7 +128,9 @@ class VideoSeo
 
         add_filter('wpseo_twitter_title', $title);
         add_filter('wpseo_twitter_description', $description);
-        add_filter('wpseo_twitter_image', $thumbnail);
+        add_filter('wpseo_twitter_image', function ($image) use ($socialImageUrl) {
+            return $socialImageUrl ?? $image;
+        });
 
         $broadcastDateIso = $video->getBroadcastDate()?->format('c');
 
@@ -159,8 +152,8 @@ class VideoSeo
             return $presenters;
         });
 
-        add_filter('wpseo_frontend_presentation', function ($presentation, $context) use ($video) {
-            if ($video->getThumbnail() === null) {
+        add_filter('wpseo_frontend_presentation', function ($presentation, $context) use ($socialImageUrl) {
+            if ($socialImageUrl === null) {
                 return $presentation;
             }
 

--- a/templates/archive-tv.twig
+++ b/templates/archive-tv.twig
@@ -1,6 +1,8 @@
 {% extends 'base.twig' %}
 
 {% block content %}
+    {% import 'partial/responsive-image.twig' as responsive %}
+
     <div class="max-w-960 mx-auto px-4">
         {% embed 'partial/tabs.twig' %}
             {% block title %}
@@ -21,7 +23,14 @@
             {% for post in posts %}
                 <a class="block" href="{{ post.link }}">
                     <div class="aspect-video bg-blauw rounded-sm overflow-hidden">
-                        <img class="w-full h-full object-cover" alt="{{ post.title }}" src="{{ post.thumbnail.src|imgproxy(440, 248) }}"/>
+                        {{ responsive.render(
+                            post.thumbnail.src,
+                            296,
+                            167,
+                            '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), (min-width: 640px) calc((100vw - 4rem) / 3), calc((100vw - 3rem) / 2)',
+                            post.thumbnail.alt|default(post.title, true),
+                            'w-full h-full object-cover',
+                        ) }}
                     </div>
                     <p class="text-center mt-2 font-bold text-sm text-black dark:text-gray-100">{{ post.title }}</p>
                 </a>

--- a/templates/archive-tv.twig
+++ b/templates/archive-tv.twig
@@ -24,12 +24,12 @@
                 <a class="block" href="{{ post.link }}">
                     <div class="aspect-video bg-blauw rounded-sm overflow-hidden">
                         {{ responsive.render(
-                            post.thumbnail.src,
-                            296,
-                            167,
-                            '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), (min-width: 640px) calc((100vw - 4rem) / 3), calc((100vw - 3rem) / 2)',
-                            post.thumbnail.alt|default(post.title, true),
-                            'w-full h-full object-cover',
+                            src: post.thumbnail.src,
+                            width: 296,
+                            height: 167,
+                            sizes: '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), (min-width: 640px) calc((100vw - 4rem) / 3), calc((100vw - 3rem) / 2)',
+                            alt: post.thumbnail.alt|default(post.title, true),
+                            class: 'w-full h-full object-cover',
                         ) }}
                     </div>
                     <p class="text-center mt-2 font-bold text-sm text-black dark:text-gray-100">{{ post.title }}</p>

--- a/templates/archive-tv.twig
+++ b/templates/archive-tv.twig
@@ -28,7 +28,7 @@
                             width: 296,
                             height: 167,
                             sizes: '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), (min-width: 640px) calc((100vw - 4rem) / 3), calc((100vw - 3rem) / 2)',
-                            alt: post.thumbnail.alt|default(post.title, true),
+                            alt: post.thumbnail.alt|default(post.title),
                             class: 'w-full h-full object-cover',
                         ) }}
                     </div>

--- a/templates/blocks/blok_dossier.twig
+++ b/templates/blocks/blok_dossier.twig
@@ -5,13 +5,14 @@
         <div class="aspect-[21/9] relative">
             <div>
                 {% set wide_image = get_image(block.term.dossier_afbeelding_breed) %}
+                {# lazy + display:none at lg keeps this from loading on desktop #}
                 {{ responsive.render(
-                    wide_image.src,
-                    1024,
-                    439,
-                    '(max-width: 1023px) 100vw, 1px',
-                    wide_image.alt|default(block.term.name, true),
-                    'object-cover absolute inset-0 w-full h-full',
+                    src: wide_image.src,
+                    width: 1024,
+                    height: 439,
+                    sizes: '100vw',
+                    alt: wide_image.alt|default(block.term.name, true),
+                    class: 'object-cover absolute inset-0 w-full h-full',
                 ) }}
                 <div class="absolute inset-x-0 -bottom-px h-32 max-h-full bg-gradient-to-t from-gray-800"></div>
             </div>
@@ -34,16 +35,16 @@
                     <a href="{{ block.term.link }}" class="text-blauw hover:bg-gray-700 inline-block px-2 py-1 rounded-sm">→ Alles over {{ block.term.name }}</a>
                 </div>
             </div>
-            <div class="col-start-1 row-start-1 relative z-10">
+            <div class="hidden lg:block col-start-1 row-start-1 relative z-10">
                 <div class="absolute inset-y-0 -inset-x-8">
                     {% set tall_image = get_image(block.term.dossier_afbeelding_hoog) %}
                     {{ responsive.render(
-                        tall_image.src,
-                        384,
-                        423,
-                        '(min-width: 1024px) 384px, 1px',
-                        tall_image.alt|default(block.term.name, true),
-                        'absolute inset-0 w-full h-full object-cover',
+                        src: tall_image.src,
+                        width: 384,
+                        height: 423,
+                        sizes: '384px',
+                        alt: tall_image.alt|default(block.term.name, true),
+                        class: 'absolute inset-0 w-full h-full object-cover',
                     ) }}
                     <div class="absolute left-0 inset-y-0 w-16 bg-gradient-to-r from-gray-800"></div>
                     <div class="absolute right-0 inset-y-0 w-1/2 bg-gradient-to-l from-gray-800"></div>

--- a/templates/blocks/blok_dossier.twig
+++ b/templates/blocks/blok_dossier.twig
@@ -11,7 +11,7 @@
                     width: 1024,
                     height: 439,
                     sizes: '100vw',
-                    alt: wide_image.alt|default(block.term.name, true),
+                    alt: wide_image.alt|default(block.term.name),
                     class: 'object-cover absolute inset-0 w-full h-full',
                 ) }}
                 <div class="absolute inset-x-0 -bottom-px h-32 max-h-full bg-gradient-to-t from-gray-800"></div>
@@ -44,7 +44,7 @@
                         width: 384,
                         height: 423,
                         sizes: '384px',
-                        alt: tall_image.alt|default(block.term.name, true),
+                        alt: tall_image.alt|default(block.term.name),
                         class: 'absolute inset-0 w-full h-full object-cover',
                     ) }}
                     <div class="absolute left-0 inset-y-0 w-16 bg-gradient-to-r from-gray-800"></div>

--- a/templates/blocks/blok_dossier.twig
+++ b/templates/blocks/blok_dossier.twig
@@ -5,7 +5,7 @@
         <div class="aspect-[21/9] relative">
             <div>
                 {% set wide_image = get_image(block.term.dossier_afbeelding_breed) %}
-                {# lazy + display:none at lg keeps this from loading on desktop #}
+                {# The lg:hidden wrapper above plus lazy loading lets current engines skip this desktop fetch. #}
                 {{ responsive.render(
                     src: wide_image.src,
                     width: 1024,

--- a/templates/blocks/blok_dossier.twig
+++ b/templates/blocks/blok_dossier.twig
@@ -1,12 +1,18 @@
+{% import 'partial/responsive-image.twig' as responsive %}
+
 <div class="bg-gray-800 text-white my-4">
     <div class="lg:hidden">
         <div class="aspect-[21/9] relative">
             <div>
-                <img
-                    class="object-cover absolute inset-0 w-full h-full" loading="lazy" alt="{{ block.term.name }}"
-                    src="{{ get_image(block.term.dossier_afbeelding_breed).src|imgproxy(1024, 439) }}"
-                    srcset="{{ get_image(block.term.dossier_afbeelding_breed).src|imgproxy(1024 * 2, 439 * 2) }} 2x"
-                />
+                {% set wide_image = get_image(block.term.dossier_afbeelding_breed) %}
+                {{ responsive.render(
+                    wide_image.src,
+                    1024,
+                    439,
+                    '(max-width: 1023px) 100vw, 1px',
+                    wide_image.alt|default(block.term.name, true),
+                    'object-cover absolute inset-0 w-full h-full',
+                ) }}
                 <div class="absolute inset-x-0 -bottom-px h-32 max-h-full bg-gradient-to-t from-gray-800"></div>
             </div>
         </div>
@@ -30,11 +36,15 @@
             </div>
             <div class="col-start-1 row-start-1 relative z-10">
                 <div class="absolute inset-y-0 -inset-x-8">
-                    <img
-                        class="absolute inset-0 w-full h-full object-cover" loading="lazy" alt="{{ block.term.name }}"
-                        src="{{ get_image(block.term.dossier_afbeelding_hoog).src|imgproxy(384, 423) }}"
-                        srcset="{{ get_image(block.term.dossier_afbeelding_hoog).src|imgproxy(384 * 2, 423 * 2) }} 2x"
-                    />
+                    {% set tall_image = get_image(block.term.dossier_afbeelding_hoog) %}
+                    {{ responsive.render(
+                        tall_image.src,
+                        384,
+                        423,
+                        '(min-width: 1024px) 384px, 1px',
+                        tall_image.alt|default(block.term.name, true),
+                        'absolute inset-0 w-full h-full object-cover',
+                    ) }}
                     <div class="absolute left-0 inset-y-0 w-16 bg-gradient-to-r from-gray-800"></div>
                     <div class="absolute right-0 inset-y-0 w-1/2 bg-gradient-to-l from-gray-800"></div>
                 </div>

--- a/templates/blocks/blok_dossier.twig
+++ b/templates/blocks/blok_dossier.twig
@@ -38,6 +38,7 @@
             <div class="hidden lg:block col-start-1 row-start-1 relative z-10">
                 <div class="absolute inset-y-0 -inset-x-8">
                     {% set tall_image = get_image(block.term.dossier_afbeelding_hoog) %}
+                    {# 384px = max-w-960 / 3 plus 2rem bleed on both sides from -inset-x-8. #}
                     {{ responsive.render(
                         src: tall_image.src,
                         width: 384,

--- a/templates/blocks/blok_dossiers_carrousel.twig
+++ b/templates/blocks/blok_dossiers_carrousel.twig
@@ -50,7 +50,7 @@
                     width: 226,
                     height: 402,
                     sizes: '(min-width: 960px) 226px, (min-width: 640px) calc((100vw - 3.5rem) / 4), calc((100vw - 3rem) / 3)',
-                    alt: image.alt|default(term.title, true),
+                    alt: image.alt|default(term.title),
                     class: 'absolute inset-0 w-full',
                 ) }}
                 <i class="block absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black opacity-60"></i>

--- a/templates/blocks/blok_dossiers_carrousel.twig
+++ b/templates/blocks/blok_dossiers_carrousel.twig
@@ -1,3 +1,5 @@
+{% import 'partial/responsive-image.twig' as responsive %}
+
 <style>
     .slider {
         --grid-columns: 3;
@@ -39,8 +41,6 @@
 </style>
 
 {% macro render_term(term) %}
-    {% import 'partial/responsive-image.twig' as responsive %}
-
     <a href="{{ term.link }}" class="block overflow-hidden slider-term bg-gray-800 rounded-sm">
         <div class="aspect-[9/16] relative">
             <div>

--- a/templates/blocks/blok_dossiers_carrousel.twig
+++ b/templates/blocks/blok_dossiers_carrousel.twig
@@ -46,12 +46,12 @@
             <div>
                 {% set image = get_image(term.meta('dossier_afbeelding_hoog')) %}
                 {{ responsive.render(
-                    image.src,
-                    226,
-                    402,
-                    '(min-width: 960px) 226px, (min-width: 640px) calc((100vw - 3.5rem) / 4), calc((100vw - 3rem) / 3)',
-                    image.alt|default(term.title, true),
-                    'absolute inset-0 w-full',
+                    src: image.src,
+                    width: 226,
+                    height: 402,
+                    sizes: '(min-width: 960px) 226px, (min-width: 640px) calc((100vw - 3.5rem) / 4), calc((100vw - 3rem) / 3)',
+                    alt: image.alt|default(term.title, true),
+                    class: 'absolute inset-0 w-full',
                 ) }}
                 <i class="block absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black opacity-60"></i>
                 <div class="block absolute left-0 right-0 bottom-0 p-4">

--- a/templates/blocks/blok_dossiers_carrousel.twig
+++ b/templates/blocks/blok_dossiers_carrousel.twig
@@ -39,11 +39,20 @@
 </style>
 
 {% macro render_term(term) %}
+    {% import 'partial/responsive-image.twig' as responsive %}
+
     <a href="{{ term.link }}" class="block overflow-hidden slider-term bg-gray-800 rounded-sm">
         <div class="aspect-[9/16] relative">
             <div>
-                <img class="absolute inset-0 w-full" loading="lazy" alt="{{ term.title }}"
-                     src="{{ get_image(term.meta('dossier_afbeelding_hoog'))|imgproxy(9 * 48, 16 * 48) }}"/>
+                {% set image = get_image(term.meta('dossier_afbeelding_hoog')) %}
+                {{ responsive.render(
+                    image.src,
+                    226,
+                    402,
+                    '(min-width: 960px) 226px, (min-width: 640px) calc((100vw - 3.5rem) / 4), calc((100vw - 3rem) / 3)',
+                    image.alt|default(term.title, true),
+                    'absolute inset-0 w-full',
+                ) }}
                 <i class="block absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black opacity-60"></i>
                 <div class="block absolute left-0 right-0 bottom-0 p-4">
                     <h2 class="block font-black text-md sm:text-xl text-white text-center">{{ term.title }}</h2>

--- a/templates/blocks/blok_fragmenten_carrousel.twig
+++ b/templates/blocks/blok_fragmenten_carrousel.twig
@@ -29,7 +29,10 @@
             {% for post in block.posts[1:] %}
                 <div class="block w-96 flex-none mx-2 !text-white"
                      style="width: calc((100vw - (1rem * 2) - (1rem * 2)) /2); min-width: 160px; max-width: 220px">
-                    {{ include('partial/tile-fragment.twig', {post: post}) }}
+                    {{ include('partial/tile-fragment.twig', {
+                        post: post,
+                        sizes: '(max-width: 383px) 160px, (max-width: 503px) calc((100vw - 4rem) / 2), 220px',
+                    }) }}
                 </div>
             {% endfor %}
         </div>

--- a/templates/blocks/blok_fragmenten_carrousel.twig
+++ b/templates/blocks/blok_fragmenten_carrousel.twig
@@ -9,7 +9,11 @@
         <article>
             <a href="{{ post.link }}" class="grid sm:grid-cols-2 gap-4">
             <div>
-                {{ include('partial/post-thumbnail.twig', {post: post, width: 472}) }}
+                {{ include('partial/post-thumbnail.twig', {
+                    post: post,
+                    width: 472,
+                    sizes: '(min-width: 960px) 456px, (min-width: 640px) calc((100vw - 3rem) / 2), calc(100vw - 2rem)',
+                }) }}
             </div>
 
             <div>

--- a/templates/blocks/blok_top_stories.twig
+++ b/templates/blocks/blok_top_stories.twig
@@ -15,7 +15,7 @@
                         sizes: loop.first
                             ? '(min-width: 960px) 439px, (min-width: 640px) calc((100vw - 2rem) * 0.4735043), 100vw'
                             : '(min-width: 960px) 244px, (min-width: 640px) calc((100vw - 2rem) * 0.2632478), calc((100vw - 0.125rem) / 2)',
-                        alt: post.thumbnail.alt|default(post.title, true),
+                        alt: post.thumbnail.alt|default(post.title),
                         class: 'object-cover w-full h-full absolute inset-0',
                         loading: loop.first ? 'eager' : 'lazy',
                     ) }}

--- a/templates/blocks/blok_top_stories.twig
+++ b/templates/blocks/blok_top_stories.twig
@@ -1,11 +1,21 @@
+{% import 'partial/responsive-image.twig' as responsive %}
+
 <div class="max-w-960 mx-auto my-4 mt-0 sm:mt-4 sm:px-4">
     <div class="grid grid-stories gap-0.5">
         {% for post in block.posts %}
             <article class="{{ loop.first ? 'main' }} flex flex-col" data-post-id="{{ post.id }}">
                 <a class="block relative grow bg-gray-200 dark:bg-gray-800 {{ loop.first ? 'sm:stories-pad' }}" href="{{ post.link }}">
-                    <img class="object-cover w-full h-full absolute inset-0" loading="lazy" alt="{{ post.thumbnail.alt }}"
-                         src="{{ post.thumbnail.src|imgproxy(455, 384) }}"
-                         srcset="{{ post.thumbnail.src|imgproxy(910, 768) }} 2x"/>
+                    {{ responsive.render(
+                        post.thumbnail.src,
+                        loop.first ? 640 : 320,
+                        loop.first ? 540 : 270,
+                        loop.first
+                            ? '(min-width: 960px) 439px, (min-width: 640px) calc((100vw - 2rem) * 0.4735043), 100vw'
+                            : '(min-width: 960px) 244px, (min-width: 640px) calc((100vw - 2rem) * 0.2632478), calc((100vw - 0.125rem) / 2)',
+                        post.thumbnail.alt|default(post.title, true),
+                        'object-cover w-full h-full absolute inset-0',
+                        loop.first ? 'eager' : 'lazy',
+                    ) }}
                     <div class="relative sm:absolute inset-0 flex flex-col justify-end zw-block-content">
                     <span class="block p-4 pt-14 bg-gradient-to-b from-transparent"
                           style="--tw-gradient-to: rgba(0,0,0,.60);">

--- a/templates/blocks/blok_top_stories.twig
+++ b/templates/blocks/blok_top_stories.twig
@@ -5,16 +5,18 @@
         {% for post in block.posts %}
             <article class="{{ loop.first ? 'main' }} flex flex-col" data-post-id="{{ post.id }}">
                 <a class="block relative grow bg-gray-200 dark:bg-gray-800 {{ loop.first ? 'sm:stories-pad' }}" href="{{ post.link }}">
+                    {# 0.4735043 / 0.2632478 are the .grid-stories column fractions from assets/style.css
+                       (grid-template-columns: 47.35043% 1fr 1fr): main column and (100% - 47.35043%) / 2 #}
                     {{ responsive.render(
-                        post.thumbnail.src,
-                        loop.first ? 640 : 320,
-                        loop.first ? 540 : 270,
-                        loop.first
+                        src: post.thumbnail.src,
+                        width: loop.first ? 640 : 320,
+                        height: loop.first ? 540 : 270,
+                        sizes: loop.first
                             ? '(min-width: 960px) 439px, (min-width: 640px) calc((100vw - 2rem) * 0.4735043), 100vw'
                             : '(min-width: 960px) 244px, (min-width: 640px) calc((100vw - 2rem) * 0.2632478), calc((100vw - 0.125rem) / 2)',
-                        post.thumbnail.alt|default(post.title, true),
-                        'object-cover w-full h-full absolute inset-0',
-                        loop.first ? 'eager' : 'lazy',
+                        alt: post.thumbnail.alt|default(post.title, true),
+                        class: 'object-cover w-full h-full absolute inset-0',
+                        loading: loop.first ? 'eager' : 'lazy',
                     ) }}
                     <div class="relative sm:absolute inset-0 flex flex-col justify-end zw-block-content">
                     <span class="block p-4 pt-14 bg-gradient-to-b from-transparent"

--- a/templates/blocks/blok_top_stories.twig
+++ b/templates/blocks/blok_top_stories.twig
@@ -6,7 +6,8 @@
             <article class="{{ loop.first ? 'main' }} flex flex-col" data-post-id="{{ post.id }}">
                 <a class="block relative grow bg-gray-200 dark:bg-gray-800 {{ loop.first ? 'sm:stories-pad' }}" href="{{ post.link }}">
                     {# 0.4735043 / 0.2632478 are the .grid-stories column fractions from assets/style.css
-                       (grid-template-columns: 47.35043% 1fr 1fr): main column and (100% - 47.35043%) / 2 #}
+                       (grid-template-columns: 47.35043% 1fr 1fr): main column and (100% - 47.35043%) / 2.
+                       The gap is ignored here; the slight overestimate is safe for image selection. #}
                     {{ responsive.render(
                         src: post.thumbnail.src,
                         width: loop.first ? 640 : 320,

--- a/templates/blocks/blok_tv_gemist.twig
+++ b/templates/blocks/blok_tv_gemist.twig
@@ -1,3 +1,5 @@
+{% import 'partial/responsive-image.twig' as responsive %}
+
 <div class="bg-gray-800 text-white dark:border-t dark:border-gray-700/50">
     <div class="w-full mx-auto max-w-960 py-4 px-4">
         {% if block.tekst_boven_videos %}
@@ -7,7 +9,14 @@
         <div class="grid sm:grid-cols-2 gap-4">
             {% for item in block.videos %}
                 <a href="{{ item.show.link }}?v={{ item.video.id }}" class="grid sm:block md:grid grid-cols-2 gap-4 hover:bg-gray-700">
-                    <img src="{{ item.video.thumbnail|imgproxy(330, 168) }}" alt="{{ item.show.title }} - {{ item.video.name }}" width="330" height="168" loading="lazy"/>
+                    {{ responsive.render(
+                        item.video.thumbnail,
+                        330,
+                        168,
+                        '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), calc((100vw - 3rem) / 2)',
+                        item.show.title ~ ' - ' ~ item.video.name,
+                        'w-full',
+                    ) }}
                     <div class="sm:mt-4 md:m-0">
                         <h3 class="font-bold">{{ item.show.title }}</h3>
                         <p>{{ item.video.name }}</p>

--- a/templates/blocks/blok_tv_gemist.twig
+++ b/templates/blocks/blok_tv_gemist.twig
@@ -10,12 +10,12 @@
             {% for item in block.videos %}
                 <a href="{{ item.show.link }}?v={{ item.video.id }}" class="grid sm:block md:grid grid-cols-2 gap-4 hover:bg-gray-700">
                     {{ responsive.render(
-                        item.video.thumbnail,
-                        330,
-                        168,
-                        '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), calc((100vw - 3rem) / 2)',
-                        item.show.title ~ ' - ' ~ item.video.name,
-                        'w-full',
+                        src: item.video.thumbnail,
+                        width: 330,
+                        height: 168,
+                        sizes: '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), calc((100vw - 3rem) / 2)',
+                        alt: item.show.title ~ ' - ' ~ item.video.name,
+                        class: 'w-full',
                     ) }}
                     <div class="sm:mt-4 md:m-0">
                         <h3 class="font-bold">{{ item.show.title }}</h3>

--- a/templates/dossier.twig
+++ b/templates/dossier.twig
@@ -10,14 +10,16 @@
         <div class="aspect-[21/9] relative">
             <div>
                 {% set wide_image = get_image(term.dossier_afbeelding_breed) %}
+                {# eager for mobile LCP; it also fetches on desktop where lg:hidden applies,
+                   so the 1px clause steers desktop to the smallest candidate #}
                 {{ responsive.render(
-                    wide_image.src,
-                    1024,
-                    439,
-                    '(max-width: 1023px) 100vw, 1px',
-                    wide_image.alt|default(term.name, true),
-                    'object-cover absolute inset-0 w-full h-full',
-                    'eager',
+                    src: wide_image.src,
+                    width: 1024,
+                    height: 439,
+                    sizes: '(max-width: 1023px) 100vw, 1px',
+                    alt: wide_image.alt|default(term.name, true),
+                    class: 'object-cover absolute inset-0 w-full h-full',
+                    loading: 'eager',
                 ) }}
                 <div class="absolute inset-x-0 bottom-0 h-32 max-h-full bg-gradient-to-t from-white dark:from-gray-800"></div>
             </div>
@@ -39,12 +41,12 @@
                         <div>
                             {% set tall_image = get_image(term.meta('dossier_afbeelding_hoog')) %}
                             {{ responsive.render(
-                                tall_image.src,
-                                299,
-                                532,
-                                '(min-width: 1024px) 299px, 1px',
-                                tall_image.alt|default(term.name, true),
-                                'absolute inset-0 w-full',
+                                src: tall_image.src,
+                                width: 299,
+                                height: 532,
+                                sizes: '299px',
+                                alt: tall_image.alt|default(term.name, true),
+                                class: 'absolute inset-0 w-full',
                             ) }}
                         </div>
                     </div>

--- a/templates/dossier.twig
+++ b/templates/dossier.twig
@@ -17,7 +17,7 @@
                     width: 1024,
                     height: 439,
                     sizes: '(max-width: 1023px) 100vw, 1px',
-                    alt: wide_image.alt|default(term.name, true),
+                    alt: wide_image.alt|default(term.name),
                     class: 'object-cover absolute inset-0 w-full h-full',
                     loading: 'eager',
                 ) }}
@@ -45,7 +45,7 @@
                                 width: 299,
                                 height: 532,
                                 sizes: '299px',
-                                alt: tall_image.alt|default(term.name, true),
+                                alt: tall_image.alt|default(term.name),
                                 class: 'absolute inset-0 w-full',
                             ) }}
                         </div>

--- a/templates/dossier.twig
+++ b/templates/dossier.twig
@@ -10,8 +10,8 @@
         <div class="aspect-[21/9] relative">
             <div>
                 {% set wide_image = get_image(term.dossier_afbeelding_breed) %}
-                {# eager for mobile LCP; it also fetches on desktop where lg:hidden applies,
-                   so the 1px clause steers desktop to the smallest candidate #}
+                {# Eager for mobile LCP. Unlike blok_dossier.twig's lazy hero, this can fetch on desktop,
+                   so the 1px clause steers the lg:hidden desktop case to the smallest candidate. #}
                 {{ responsive.render(
                     src: wide_image.src,
                     width: 1024,

--- a/templates/dossier.twig
+++ b/templates/dossier.twig
@@ -4,13 +4,21 @@
 {% extends 'archive.twig' %}
 
 {% block content %}
+    {% import 'partial/responsive-image.twig' as responsive %}
+
     <div class="lg:hidden">
         <div class="aspect-[21/9] relative">
             <div>
-                <img class="object-cover absolute inset-0 w-full h-full" alt="{{ term.name }}"
-                     src="{{ get_image(term.dossier_afbeelding_breed).src|imgproxy(1024, 439) }}"
-                     srcset="{{ get_image(term.dossier_afbeelding_breed).src|imgproxy(1024 * 2, 439 * 2) }} 2x"
-                     />
+                {% set wide_image = get_image(term.dossier_afbeelding_breed) %}
+                {{ responsive.render(
+                    wide_image.src,
+                    1024,
+                    439,
+                    '(max-width: 1023px) 100vw, 1px',
+                    wide_image.alt|default(term.name, true),
+                    'object-cover absolute inset-0 w-full h-full',
+                    'eager',
+                ) }}
                 <div class="absolute inset-x-0 bottom-0 h-32 max-h-full bg-gradient-to-t from-white dark:from-gray-800"></div>
             </div>
 
@@ -29,8 +37,15 @@
                 <div class="hidden lg:block overflow-hidden bg-gray-800 rounded-sm">
                     <div class="aspect-[9/16] relative">
                         <div>
-                            <img class="absolute inset-0 w-full" loading="lazy" alt="{{ term.name }}"
-                                 src="{{ get_image(term.meta('dossier_afbeelding_hoog'))|imgproxy(9 * 48, 16 * 48) }}"/>
+                            {% set tall_image = get_image(term.meta('dossier_afbeelding_hoog')) %}
+                            {{ responsive.render(
+                                tall_image.src,
+                                299,
+                                532,
+                                '(min-width: 1024px) 299px, 1px',
+                                tall_image.alt|default(term.name, true),
+                                'absolute inset-0 w-full',
+                            ) }}
                         </div>
                     </div>
                 </div>

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -9,18 +9,9 @@
                         <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg sm:rounded-xl bg-gradient-to-br from-groen/20 to-groen/5 border border-groen/20 flex items-center justify-center shrink-0">
                             {% set site_icon = function('get_site_icon_url', 64) %}
                             {% if site_icon %}
-                                {% set site_icon_retina = function('get_site_icon_url', 128) %}
-                                <img
-                                    src="{{ site_icon }}"
-                                    srcset="{{ site_icon }} 64w{% if site_icon_retina %}, {{ site_icon_retina }} 128w{% endif %}"
-                                    sizes="(min-width: 640px) 40px, 32px"
-                                    width="40"
-                                    height="40"
-                                    loading="lazy"
-                                    decoding="async"
-                                    alt=""
-                                    class="w-8 h-8 sm:w-10 sm:h-10 rounded-md sm:rounded-lg"
-                                >
+                                {# get_site_icon_url(64) resolves to the smallest generated crop (180px), plenty for this 32-40px slot #}
+                                <img src="{{ site_icon }}" width="40" height="40" loading="lazy" decoding="async" alt=""
+                                     class="w-8 h-8 sm:w-10 sm:h-10 rounded-md sm:rounded-lg">
                             {% else %}
                                 <svg class="w-5 h-5 sm:w-7 sm:h-7 text-groen" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -9,7 +9,6 @@
                         <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg sm:rounded-xl bg-gradient-to-br from-groen/20 to-groen/5 border border-groen/20 flex items-center justify-center shrink-0">
                             {% set site_icon = function('get_site_icon_url', 64) %}
                             {% if site_icon %}
-                                {# get_site_icon_url(64) returns the smallest crop >= 64px; WP's default 32/180/192/270 site-icon crops resolve this to 180px. #}
                                 <img src="{{ site_icon }}" width="40" height="40" loading="lazy" decoding="async" alt=""
                                      class="w-8 h-8 sm:w-10 sm:h-10 rounded-md sm:rounded-lg">
                             {% else %}

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -9,7 +9,7 @@
                         <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg sm:rounded-xl bg-gradient-to-br from-groen/20 to-groen/5 border border-groen/20 flex items-center justify-center shrink-0">
                             {% set site_icon = function('get_site_icon_url', 64) %}
                             {% if site_icon %}
-                                {# get_site_icon_url(64) resolves to the smallest generated crop (180px), plenty for this 32-40px slot #}
+                                {# get_site_icon_url(64) returns the smallest crop >= 64px; WP's default 32/180/192/270 site-icon crops resolve this to 180px. #}
                                 <img src="{{ site_icon }}" width="40" height="40" loading="lazy" decoding="async" alt=""
                                      class="w-8 h-8 sm:w-10 sm:h-10 rounded-md sm:rounded-lg">
                             {% else %}

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -9,7 +9,18 @@
                         <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-lg sm:rounded-xl bg-gradient-to-br from-groen/20 to-groen/5 border border-groen/20 flex items-center justify-center shrink-0">
                             {% set site_icon = function('get_site_icon_url', 64) %}
                             {% if site_icon %}
-                                <img src="{{ site_icon }}" alt="" class="w-8 h-8 sm:w-10 sm:h-10 rounded-md sm:rounded-lg">
+                                {% set site_icon_retina = function('get_site_icon_url', 128) %}
+                                <img
+                                    src="{{ site_icon }}"
+                                    srcset="{{ site_icon }} 64w{% if site_icon_retina %}, {{ site_icon_retina }} 128w{% endif %}"
+                                    sizes="(min-width: 640px) 40px, 32px"
+                                    width="40"
+                                    height="40"
+                                    loading="lazy"
+                                    decoding="async"
+                                    alt=""
+                                    class="w-8 h-8 sm:w-10 sm:h-10 rounded-md sm:rounded-lg"
+                                >
                             {% else %}
                                 <svg class="w-5 h-5 sm:w-7 sm:h-7 text-groen" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />

--- a/templates/page-tv-guide.twig
+++ b/templates/page-tv-guide.twig
@@ -1,6 +1,8 @@
 {% extends 'base.twig' %}
 
 {% block content %}
+    {% import 'partial/responsive-image.twig' as responsive %}
+
     <div class="max-w-960 mx-auto px-4">
         {% embed 'partial/tabs.twig' %}
             {% block title %}
@@ -21,12 +23,26 @@
                 <a class="my-4 flex flex-row" href="{{ broadcast.show.link }}">
                     <div class="w-1/2 sm:w-1/3 flex-none pr-2">
                         <div class="aspect-video bg-blauw rounded-sm overflow-hidden">
+                            {% set thumbnail_sizes = '(min-width: 640px) 174px, (min-width: 576px) 264px, calc((100vw - 3rem) / 2)' %}
                             {% if broadcast.show.thumbnail %}
-                                <img class="w-full h-full object-cover" alt="{{ broadcast.name }}"
-                                     src="{{ broadcast.show.thumbnail.src|imgproxy(440, 248) }}"/>
+                                {{ responsive.render(
+                                    broadcast.show.thumbnail.src,
+                                    264,
+                                    149,
+                                    thumbnail_sizes,
+                                    broadcast.show.thumbnail.alt|default(broadcast.name, true),
+                                    'w-full h-full object-cover',
+                                ) }}
                             {% else %}
-                                <img class="w-full h-full object-cover" alt="{{ broadcast.name }}"
-                                     src="{{ get_image(options.tv_fallback_img).src|imgproxy(440, 248) }}"/>
+                                {% set fallback_image = get_image(options.tv_fallback_img) %}
+                                {{ responsive.render(
+                                    fallback_image.src,
+                                    264,
+                                    149,
+                                    thumbnail_sizes,
+                                    broadcast.name,
+                                    'w-full h-full object-cover',
+                                ) }}
                             {% endif %}
                         </div>
                     </div>

--- a/templates/page-tv-guide.twig
+++ b/templates/page-tv-guide.twig
@@ -17,33 +17,23 @@
     </div>
 
     <div class="w-full max-w-xl mx-auto px-4">
+        {% set thumbnail_sizes = '(min-width: 640px) 174px, (min-width: 576px) 264px, calc((100vw - 3rem) / 2)' %}
+        {% set fallback_image = get_image(options.tv_fallback_img) %}
         {% for day in schedule.days %}
             <h2 class="font-bold text-2xl text-black dark:text-gray-100">{{ day.name }}</h2>
             {% for broadcast in day.television %}
                 <a class="my-4 flex flex-row" href="{{ broadcast.show.link }}">
                     <div class="w-1/2 sm:w-1/3 flex-none pr-2">
                         <div class="aspect-video bg-blauw rounded-sm overflow-hidden">
-                            {% set thumbnail_sizes = '(min-width: 640px) 174px, (min-width: 576px) 264px, calc((100vw - 3rem) / 2)' %}
-                            {% if broadcast.show.thumbnail %}
-                                {{ responsive.render(
-                                    broadcast.show.thumbnail.src,
-                                    264,
-                                    149,
-                                    thumbnail_sizes,
-                                    broadcast.show.thumbnail.alt|default(broadcast.name, true),
-                                    'w-full h-full object-cover',
-                                ) }}
-                            {% else %}
-                                {% set fallback_image = get_image(options.tv_fallback_img) %}
-                                {{ responsive.render(
-                                    fallback_image.src,
-                                    264,
-                                    149,
-                                    thumbnail_sizes,
-                                    broadcast.name,
-                                    'w-full h-full object-cover',
-                                ) }}
-                            {% endif %}
+                            {% set thumbnail = broadcast.show.thumbnail ?: fallback_image %}
+                            {{ responsive.render(
+                                src: thumbnail.src,
+                                width: 264,
+                                height: 149,
+                                sizes: thumbnail_sizes,
+                                alt: thumbnail.alt|default(broadcast.name, true),
+                                class: 'w-full h-full object-cover',
+                            ) }}
                         </div>
                     </div>
                     <div>

--- a/templates/page-tv-guide.twig
+++ b/templates/page-tv-guide.twig
@@ -31,7 +31,7 @@
                                 width: 264,
                                 height: 149,
                                 sizes: thumbnail_sizes,
-                                alt: thumbnail.alt|default(broadcast.name, true),
+                                alt: thumbnail.alt|default(broadcast.name),
                                 class: 'w-full h-full object-cover',
                             ) }}
                         </div>

--- a/templates/partial/gallery.twig
+++ b/templates/partial/gallery.twig
@@ -1,11 +1,20 @@
 {% macro render_item(item, gallery) %}
+    {% import 'partial/responsive-image.twig' as responsive %}
+    {% set image = responsive.render(
+        src: item.image.src,
+        width: item.image.width,
+        height: item.image.height,
+        sizes: item.image.sizes,
+        alt: item.image.alt,
+        class: item.image.class,
+    ) %}
     <figure class="{{ item.classes|e }}" role="listitem">
         {% if item.link %}
             <a class="absolute inset-0 block" href="{{ item.link|e }}" aria-label="{{ item.label|e }}">
-                {{ _self.render_image(item.image) }}
+                {{ image }}
             </a>
         {% else %}
-            {{ _self.render_image(item.image) }}
+            {{ image }}
         {% endif %}
 
         {% if gallery.type != 'circle' and item.caption %}
@@ -14,18 +23,6 @@
             </figcaption>
         {% endif %}
     </figure>
-{% endmacro %}
-
-{% macro render_image(image) %}
-    <img class="{{ image.class|e('html_attr') }}"
-         src="{{ image.src|imgproxy(image.width, image.height)|e('html_attr') }}"
-         srcset="{{ image.srcset|e('html_attr') }}"
-         sizes="{{ image.sizes|e('html_attr') }}"
-         alt="{{ image.alt|e('html_attr') }}"
-         width="{{ image.width|e('html_attr') }}"
-         height="{{ image.height|e('html_attr') }}"
-         loading="{{ image.loading|e('html_attr') }}"
-         decoding="{{ image.decoding|e('html_attr') }}">
 {% endmacro %}
 
 {% import _self as gallery_macros %}

--- a/templates/partial/gallery.twig
+++ b/templates/partial/gallery.twig
@@ -19,7 +19,7 @@
 {% macro render_image(image) %}
     <img class="{{ image.class|e('html_attr') }}"
          src="{{ image.src|imgproxy(image.width, image.height)|e('html_attr') }}"
-         srcset="{%- for candidate in image.srcset -%}{{ image.src|imgproxy(candidate.width, candidate.height)|e('html_attr') }} {{ candidate.descriptor|e('html_attr') }}{%- if not loop.last %}, {% endif -%}{%- endfor -%}"
+         srcset="{{ image.srcset|e('html_attr') }}"
          sizes="{{ image.sizes|e('html_attr') }}"
          alt="{{ image.alt|e('html_attr') }}"
          width="{{ image.width|e('html_attr') }}"

--- a/templates/partial/gallery.twig
+++ b/templates/partial/gallery.twig
@@ -1,5 +1,6 @@
+{% import 'partial/responsive-image.twig' as responsive %}
+
 {% macro render_item(item, gallery) %}
-    {% import 'partial/responsive-image.twig' as responsive %}
     {% set image = responsive.render(
         src: item.image.src,
         width: item.image.width,

--- a/templates/partial/post-thumbnail-4-3.twig
+++ b/templates/partial/post-thumbnail-4-3.twig
@@ -1,3 +1,5 @@
+{% import 'partial/responsive-image.twig' as responsive %}
+
 {% set showPlayButton = false %}
 {% if post.type == 'fragment' %}
     {% set showPlayButton = true %}
@@ -5,17 +7,29 @@
     {% set showPlayButton = true %}
 {% endif %}
 {% set width = width|default(228) %}
+{% set desktop_sizes = sizes|default('(min-width: 640px) ' ~ width ~ 'px, 33vw') %}
+{% set mobile_sizes = mobile_sizes|default('33vw') %}
 <div class="aspect-[4/3] sm:aspect-video relative">
     <div class="absolute inset-0 {% if dark ?? false %}bg-gray-900{% else %}bg-gray-200{% endif %}">
         {% if post.thumbnail %}
             <picture>
                 {# Desktop: 16:9 #}
-                <source media="(min-width: 640px)"
-                        srcset="{{ post.thumbnail.src|imgproxy(width, width / 16 * 9) }}, {{ post.thumbnail.src|imgproxy(width * 2, (width * 2) / 16 * 9) }} 2x">
+                {{ responsive.source(
+                    post.thumbnail.src,
+                    width,
+                    width / 16 * 9,
+                    desktop_sizes,
+                    '(min-width: 640px)',
+                ) }}
                 {# Mobile: 4:3 #}
-                <img class="w-full h-full object-cover" loading="lazy" alt="{{ post.thumbnail.alt }}"
-                     src="{{ post.thumbnail.src|imgproxy(width, width / 4 * 3) }}"
-                     srcset="{{ post.thumbnail.src|imgproxy(width * 2, (width * 2) / 4 * 3) }} 2x">
+                {{ responsive.render(
+                    post.thumbnail.src,
+                    width,
+                    width / 4 * 3,
+                    mobile_sizes,
+                    post.thumbnail.alt|default(post.title, true),
+                    'w-full h-full object-cover',
+                ) }}
             </picture>
         {% endif %}
         {% if showPlayButton %}

--- a/templates/partial/post-thumbnail-4-3.twig
+++ b/templates/partial/post-thumbnail-4-3.twig
@@ -9,7 +9,7 @@
 {% set width = width|default(228) %}
 {# The largest desktop slot in sizes is 456px (2-column grid at 960-1023px), so srcset candidates must span that slot. #}
 {% set desktop_width = max(width, 456) %}
-{% set desktop_sizes = desktop_sizes|default('(min-width: 1024px) ' ~ width ~ 'px, (min-width: 960px) 456px, (min-width: 640px) calc((100vw - 3rem) / 2), 33vw') %}
+{% set desktop_sizes = '(min-width: 1024px) ' ~ width ~ 'px, (min-width: 960px) 456px, (min-width: 640px) calc((100vw - 3rem) / 2), 33vw' %}
 <div class="aspect-[4/3] sm:aspect-video relative">
     <div class="absolute inset-0 {% if dark ?? false %}bg-gray-900{% else %}bg-gray-200{% endif %}">
         {% if post.thumbnail %}
@@ -28,7 +28,7 @@
                     width: width,
                     height: width / 4 * 3,
                     sizes: '33vw',
-                    alt: post.thumbnail.alt|default(post.title, true),
+                    alt: post.thumbnail.alt|default(post.title),
                     class: 'w-full h-full object-cover',
                 ) }}
             </picture>

--- a/templates/partial/post-thumbnail-4-3.twig
+++ b/templates/partial/post-thumbnail-4-3.twig
@@ -7,28 +7,26 @@
     {% set showPlayButton = true %}
 {% endif %}
 {% set width = width|default(228) %}
-{% set desktop_sizes = sizes|default('(min-width: 640px) ' ~ width ~ 'px, 33vw') %}
-{% set mobile_sizes = mobile_sizes|default('33vw') %}
 <div class="aspect-[4/3] sm:aspect-video relative">
     <div class="absolute inset-0 {% if dark ?? false %}bg-gray-900{% else %}bg-gray-200{% endif %}">
         {% if post.thumbnail %}
             <picture>
                 {# Desktop: 16:9 #}
                 {{ responsive.source(
-                    post.thumbnail.src,
-                    width,
-                    width / 16 * 9,
-                    desktop_sizes,
-                    '(min-width: 640px)',
+                    src: post.thumbnail.src,
+                    width: width,
+                    height: width / 16 * 9,
+                    sizes: width ~ 'px',
+                    media: '(min-width: 640px)',
                 ) }}
                 {# Mobile: 4:3 #}
                 {{ responsive.render(
-                    post.thumbnail.src,
-                    width,
-                    width / 4 * 3,
-                    mobile_sizes,
-                    post.thumbnail.alt|default(post.title, true),
-                    'w-full h-full object-cover',
+                    src: post.thumbnail.src,
+                    width: width,
+                    height: width / 4 * 3,
+                    sizes: '33vw',
+                    alt: post.thumbnail.alt|default(post.title, true),
+                    class: 'w-full h-full object-cover',
                 ) }}
             </picture>
         {% endif %}

--- a/templates/partial/post-thumbnail-4-3.twig
+++ b/templates/partial/post-thumbnail-4-3.twig
@@ -7,6 +7,8 @@
     {% set showPlayButton = true %}
 {% endif %}
 {% set width = width|default(228) %}
+{# The largest desktop slot in sizes is 456px (2-column grid at 960-1023px), so srcset candidates must span that slot. #}
+{% set desktop_width = max(width, 456) %}
 {% set desktop_sizes = desktop_sizes|default('(min-width: 1024px) ' ~ width ~ 'px, (min-width: 960px) 456px, (min-width: 640px) calc((100vw - 3rem) / 2), 33vw') %}
 <div class="aspect-[4/3] sm:aspect-video relative">
     <div class="absolute inset-0 {% if dark ?? false %}bg-gray-900{% else %}bg-gray-200{% endif %}">
@@ -15,8 +17,8 @@
                 {# Desktop: 16:9 #}
                 {{ responsive.source(
                     src: post.thumbnail.src,
-                    width: width,
-                    height: width / 16 * 9,
+                    width: desktop_width,
+                    height: desktop_width / 16 * 9,
                     sizes: desktop_sizes,
                     media: '(min-width: 640px)',
                 ) }}

--- a/templates/partial/post-thumbnail-4-3.twig
+++ b/templates/partial/post-thumbnail-4-3.twig
@@ -7,6 +7,7 @@
     {% set showPlayButton = true %}
 {% endif %}
 {% set width = width|default(228) %}
+{% set desktop_sizes = desktop_sizes|default('(min-width: 1024px) ' ~ width ~ 'px, (min-width: 960px) 456px, (min-width: 640px) calc((100vw - 3rem) / 2), 33vw') %}
 <div class="aspect-[4/3] sm:aspect-video relative">
     <div class="absolute inset-0 {% if dark ?? false %}bg-gray-900{% else %}bg-gray-200{% endif %}">
         {% if post.thumbnail %}
@@ -16,7 +17,7 @@
                     src: post.thumbnail.src,
                     width: width,
                     height: width / 16 * 9,
-                    sizes: width ~ 'px',
+                    sizes: desktop_sizes,
                     media: '(min-width: 640px)',
                 ) }}
                 {# Mobile: 4:3 #}

--- a/templates/partial/post-thumbnail.twig
+++ b/templates/partial/post-thumbnail.twig
@@ -12,12 +12,12 @@
     <div class="{% if dark ?? false %}bg-gray-900{% else %}bg-gray-200{% endif %}">
         {% if post.thumbnail %}
             {{ responsive.render(
-                post.thumbnail.src,
-                width,
-                width / 16 * 9,
-                sizes,
-                post.thumbnail.alt|default(post.title, true),
-                'w-full h-full object-cover',
+                src: post.thumbnail.src,
+                width: width,
+                height: width / 16 * 9,
+                sizes: sizes,
+                alt: post.thumbnail.alt|default(post.title, true),
+                class: 'w-full h-full object-cover',
             ) }}
         {% endif %}
         {% if showPlayButton %}

--- a/templates/partial/post-thumbnail.twig
+++ b/templates/partial/post-thumbnail.twig
@@ -1,3 +1,5 @@
+{% import 'partial/responsive-image.twig' as responsive %}
+
 {% set showPlayButton = false %}
 {% if post.type == 'fragment' %}
     {% set showPlayButton = true %}
@@ -5,12 +7,18 @@
     {% set showPlayButton = true %}
 {% endif %}
 {% set width = width|default(228) %}
+{% set sizes = sizes|default('(min-width: 768px) 220px, 50vw') %}
 <div class="aspect-video relative">
     <div class="{% if dark ?? false %}bg-gray-900{% else %}bg-gray-200{% endif %}">
         {% if post.thumbnail %}
-            <img class="w-full h-full object-cover" loading="lazy" alt="{{ post.thumbnail.alt }}"
-                 src="{{ post.thumbnail.src|imgproxy(width, width / 16 * 9) }}"
-                 srcset="{{ post.thumbnail.src|imgproxy(width * 2, (width * 2) / 16 * 9) }} 2x"/>
+            {{ responsive.render(
+                post.thumbnail.src,
+                width,
+                width / 16 * 9,
+                sizes,
+                post.thumbnail.alt|default(post.title, true),
+                'w-full h-full object-cover',
+            ) }}
         {% endif %}
         {% if showPlayButton %}
             <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-8 h-8 bg-groen rounded-full ring-2 ring-white flex items-center justify-center">

--- a/templates/partial/post-thumbnail.twig
+++ b/templates/partial/post-thumbnail.twig
@@ -16,7 +16,7 @@
                 width: width,
                 height: width / 16 * 9,
                 sizes: sizes,
-                alt: post.thumbnail.alt|default(post.title, true),
+                alt: post.thumbnail.alt|default(post.title),
                 class: 'w-full h-full object-cover',
             ) }}
         {% endif %}

--- a/templates/partial/responsive-image.twig
+++ b/templates/partial/responsive-image.twig
@@ -1,0 +1,21 @@
+{% macro render(src, width, height, sizes, alt, class, loading = 'lazy') %}
+    {% set width = width|round %}
+    {% set height = height|round %}
+    <img class="{{ class|e('html_attr') }}"
+         src="{{ src|imgproxy(width, height)|e('html_attr') }}"
+         srcset="{{ responsive_image_srcset(src, width, height)|e('html_attr') }}"
+         sizes="{{ sizes|e('html_attr') }}"
+         alt="{{ alt|default('', true)|e('html_attr') }}"
+         width="{{ width|e('html_attr') }}"
+         height="{{ height|e('html_attr') }}"
+         loading="{{ loading|e('html_attr') }}"
+         decoding="async">
+{% endmacro %}
+
+{% macro source(src, width, height, sizes, media) %}
+    {% set width = width|round %}
+    {% set height = height|round %}
+    <source media="{{ media|e('html_attr') }}"
+            srcset="{{ responsive_image_srcset(src, width, height)|e('html_attr') }}"
+            sizes="{{ sizes|e('html_attr') }}">
+{% endmacro %}

--- a/templates/partial/responsive-image.twig
+++ b/templates/partial/responsive-image.twig
@@ -1,11 +1,12 @@
+{# Width/height are the largest 1x CSS-pixel slot from sizes; srcset candidates span roughly 0.5x-2x. #}
 {% macro render(src, width, height, sizes, alt, class, loading = 'lazy') %}
     {% set width = width|round %}
     {% set height = height|round %}
-    {% set srcset = responsive_image_srcset(src, width, height) %}
     {% if width > 0 and height > 0 %}
+        {% set srcset = responsive_image_srcset(src, width, height) %}
         <img class="{{ class|e('html_attr') }}"
              src="{{ src|imgproxy(width, height)|e('html_attr') }}"
-             {% if srcset %}srcset="{{ srcset|e('html_attr') }}"{% endif %}
+             srcset="{{ srcset|e('html_attr') }}"
              sizes="{{ sizes|e('html_attr') }}"
              alt="{{ alt|default('', true)|e('html_attr') }}"
              width="{{ width|e('html_attr') }}"
@@ -18,8 +19,8 @@
 {% macro source(src, width, height, sizes, media) %}
     {% set width = width|round %}
     {% set height = height|round %}
-    {% set srcset = responsive_image_srcset(src, width, height) %}
-    {% if srcset %}
+    {% if width > 0 and height > 0 %}
+        {% set srcset = responsive_image_srcset(src, width, height) %}
         <source media="{{ media|e('html_attr') }}"
                 srcset="{{ srcset|e('html_attr') }}"
                 sizes="{{ sizes|e('html_attr') }}">

--- a/templates/partial/responsive-image.twig
+++ b/templates/partial/responsive-image.twig
@@ -1,21 +1,27 @@
 {% macro render(src, width, height, sizes, alt, class, loading = 'lazy') %}
     {% set width = width|round %}
     {% set height = height|round %}
-    <img class="{{ class|e('html_attr') }}"
-         src="{{ src|imgproxy(width, height)|e('html_attr') }}"
-         srcset="{{ responsive_image_srcset(src, width, height)|e('html_attr') }}"
-         sizes="{{ sizes|e('html_attr') }}"
-         alt="{{ alt|default('', true)|e('html_attr') }}"
-         width="{{ width|e('html_attr') }}"
-         height="{{ height|e('html_attr') }}"
-         loading="{{ loading|e('html_attr') }}"
-         decoding="async">
+    {% set srcset = responsive_image_srcset(src, width, height) %}
+    {% if width > 0 and height > 0 %}
+        <img class="{{ class|e('html_attr') }}"
+             src="{{ src|imgproxy(width, height)|e('html_attr') }}"
+             {% if srcset %}srcset="{{ srcset|e('html_attr') }}"{% endif %}
+             sizes="{{ sizes|e('html_attr') }}"
+             alt="{{ alt|default('', true)|e('html_attr') }}"
+             width="{{ width|e('html_attr') }}"
+             height="{{ height|e('html_attr') }}"
+             loading="{{ loading|e('html_attr') }}"
+             decoding="async">
+    {% endif %}
 {% endmacro %}
 
 {% macro source(src, width, height, sizes, media) %}
     {% set width = width|round %}
     {% set height = height|round %}
-    <source media="{{ media|e('html_attr') }}"
-            srcset="{{ responsive_image_srcset(src, width, height)|e('html_attr') }}"
-            sizes="{{ sizes|e('html_attr') }}">
+    {% set srcset = responsive_image_srcset(src, width, height) %}
+    {% if srcset %}
+        <source media="{{ media|e('html_attr') }}"
+                srcset="{{ srcset|e('html_attr') }}"
+                sizes="{{ sizes|e('html_attr') }}">
+    {% endif %}
 {% endmacro %}

--- a/templates/partial/responsive-image.twig
+++ b/templates/partial/responsive-image.twig
@@ -8,7 +8,7 @@
              src="{{ src|imgproxy(width, height)|e('html_attr') }}"
              srcset="{{ srcset|e('html_attr') }}"
              sizes="{{ sizes|e('html_attr') }}"
-             alt="{{ alt|default('', true)|e('html_attr') }}"
+             alt="{{ alt|default('')|e('html_attr') }}"
              width="{{ width|e('html_attr') }}"
              height="{{ height|e('html_attr') }}"
              loading="{{ loading|e('html_attr') }}"

--- a/templates/partial/tile-fm-show.twig
+++ b/templates/partial/tile-fm-show.twig
@@ -4,12 +4,12 @@
     <div class="absolute inset-0 bg-gray-50 text-gray-800 rounded-sm overflow-hidden">
         {% if post.thumbnail %}
             {{ responsive.render(
-                post.thumbnail.src,
-                320,
-                180,
-                '(min-width: 960px) 299px, (min-width: 768px) calc((100vw - 4rem) / 3), (min-width: 640px) calc((100vw - 3rem) / 2), calc(100vw - 2rem)',
-                post.thumbnail.alt|default(post.title, true),
-                'absolute inset-0 w-full h-full object-cover',
+                src: post.thumbnail.src,
+                width: 320,
+                height: 180,
+                sizes: '(min-width: 960px) 299px, (min-width: 768px) calc((100vw - 4rem) / 3), (min-width: 640px) calc((100vw - 3rem) / 2), calc(100vw - 2rem)',
+                alt: post.thumbnail.alt|default(post.title, true),
+                class: 'absolute inset-0 w-full h-full object-cover',
             ) }}
         {% endif %}
         <div class="absolute flex flex-col inset-x-0 bottom-0 px-4 pb-3 pt-12 bg-gradient-to-b from-transparent to-gray-50 dark:to-gray-900">

--- a/templates/partial/tile-fm-show.twig
+++ b/templates/partial/tile-fm-show.twig
@@ -1,8 +1,16 @@
+{% import 'partial/responsive-image.twig' as responsive %}
+
 <a class="block aspect-video relative" href="{{ post.link }}">
     <div class="absolute inset-0 bg-gray-50 text-gray-800 rounded-sm overflow-hidden">
         {% if post.thumbnail %}
-            <img class="absolute inset-0 w-full h-full object-cover"
-                 src="{{ post.thumbnail.src|imgproxy(320, 180) }}"/>
+            {{ responsive.render(
+                post.thumbnail.src,
+                320,
+                180,
+                '(min-width: 960px) 299px, (min-width: 768px) calc((100vw - 4rem) / 3), (min-width: 640px) calc((100vw - 3rem) / 2), calc(100vw - 2rem)',
+                post.thumbnail.alt|default(post.title, true),
+                'absolute inset-0 w-full h-full object-cover',
+            ) }}
         {% endif %}
         <div class="absolute flex flex-col inset-x-0 bottom-0 px-4 pb-3 pt-12 bg-gradient-to-b from-transparent to-gray-50 dark:to-gray-900">
             <h1 class="uppercase font-round font-black text-2xl text-black dark:text-white">{{ post.title }}</h1>

--- a/templates/partial/tile-fm-show.twig
+++ b/templates/partial/tile-fm-show.twig
@@ -8,7 +8,7 @@
                 width: 320,
                 height: 180,
                 sizes: '(min-width: 960px) 299px, (min-width: 768px) calc((100vw - 4rem) / 3), (min-width: 640px) calc((100vw - 3rem) / 2), calc(100vw - 2rem)',
-                alt: post.thumbnail.alt|default(post.title, true),
+                alt: post.thumbnail.alt|default(post.title),
                 class: 'absolute inset-0 w-full h-full object-cover',
             ) }}
         {% endif %}

--- a/templates/partial/tile-fragment.twig
+++ b/templates/partial/tile-fragment.twig
@@ -1,6 +1,6 @@
 <article data-post-id="{{ post.id }}">
     <a class="block" href="{{ post.link }}">
-    {{ include('partial/post-thumbnail.twig', {post: post}) }}
+    {{ include('partial/post-thumbnail.twig', {post: post, sizes: sizes|default(null)}) }}
     <div class="pt-2">
         {% if region ?? true %}
             {{ include('partial/tag-region.twig', {region: post.region, link: false}) }}

--- a/templates/partial/tile.twig
+++ b/templates/partial/tile.twig
@@ -11,7 +11,7 @@
                 width: 400,
                 height: 225,
                 sizes: '(min-width: 1024px) 299px, (min-width: 640px) calc((100vw - 3rem) / 2), calc(100vw - 2rem)',
-                alt: post.thumbnail.alt|default(post.title, true),
+                alt: post.thumbnail.alt|default(post.title),
                 class: 'w-full',
             ) }}
         {% endif %}

--- a/templates/partial/tile.twig
+++ b/templates/partial/tile.twig
@@ -5,13 +5,14 @@
         <h2 class="h2 text-black dark:text-white"><a href="{{ post.link }}">{{ post.title }}</a></h2>
         <p class='text-black dark:text-gray-200'>{{ post.excerpt }}</p>
         {% if post.get_thumbnail %}
+            {# Sized for the search results grid (search.twig): 3 cols >= lg, 2 cols >= sm, 1 col below #}
             {{ responsive.render(
-                post.thumbnail.src,
-                228,
-                128,
-                '(min-width: 768px) 228px, 100vw',
-                post.thumbnail.alt|default(post.title, true),
-                'w-full',
+                src: post.thumbnail.src,
+                width: 299,
+                height: 168,
+                sizes: '(min-width: 1024px) 299px, (min-width: 640px) calc((100vw - 3rem) / 2), calc(100vw - 2rem)',
+                alt: post.thumbnail.alt|default(post.title, true),
+                class: 'w-full',
             ) }}
         {% endif %}
     {% endblock %}

--- a/templates/partial/tile.twig
+++ b/templates/partial/tile.twig
@@ -8,8 +8,8 @@
             {# Sized for the search results grid (search.twig): 3 cols >= lg, 2 cols >= sm, 1 col below #}
             {{ responsive.render(
                 src: post.thumbnail.src,
-                width: 299,
-                height: 168,
+                width: 400,
+                height: 225,
                 sizes: '(min-width: 1024px) 299px, (min-width: 640px) calc((100vw - 3rem) / 2), calc(100vw - 2rem)',
                 alt: post.thumbnail.alt|default(post.title, true),
                 class: 'w-full',

--- a/templates/partial/tile.twig
+++ b/templates/partial/tile.twig
@@ -1,9 +1,18 @@
+{% import 'partial/responsive-image.twig' as responsive %}
+
 <article class="tease tease-{{ post.post_type }}" id="tease-{{ post.ID }}">
     {% block content %}
         <h2 class="h2 text-black dark:text-white"><a href="{{ post.link }}">{{ post.title }}</a></h2>
         <p class='text-black dark:text-gray-200'>{{ post.excerpt }}</p>
         {% if post.get_thumbnail %}
-            <img src="{{ post.thumbnail.src }}" alt="{{ post.thumbnail.alt }}" />
+            {{ responsive.render(
+                post.thumbnail.src,
+                228,
+                128,
+                '(min-width: 768px) 228px, 100vw',
+                post.thumbnail.alt|default(post.title, true),
+                'w-full',
+            ) }}
         {% endif %}
     {% endblock %}
 </article>

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -12,7 +12,7 @@
                         width: 928,
                         height: 928 / 21 * 9,
                         sizes: '(min-width: 960px) 928px, (min-width: 768px) calc(100vw - 2rem), 100vw',
-                        alt: post.thumbnail.alt|default(post.title, true),
+                        alt: post.thumbnail.alt|default(post.title),
                         class: 'absolute inset-0 w-full h-full object-cover bg-gray-200 dark:bg-gray-700',
                         loading: 'eager',
                     ) }}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -1,13 +1,21 @@
 {% extends 'base.twig' %}
 
 {% block content %}
+    {% import 'partial/responsive-image.twig' as responsive %}
+
     <article id="post-{{ post.id }}" class="{{ post.class }}">
         <div class="mx-auto max-w-960 md:px-4 md:pt-8">
             <div class="aspect-[21/9] relative">
                 {% if post.thumbnail %}
-                    <img src="{{ post.thumbnail.src|imgproxy(960, 960 / 21 * 9) }}"
-                         srcset="{{ post.thumbnail.src|imgproxy(1920, 1920 / 21 * 9) }} 2x"
-                         alt="{{ post.title }}" class="absolute inset-0 bg-gray-200 dark:bg-gray-700 ">
+                    {{ responsive.render(
+                        post.thumbnail.src,
+                        928,
+                        928 / 21 * 9,
+                        '(min-width: 960px) 928px, (min-width: 768px) calc(100vw - 2rem), 100vw',
+                        post.thumbnail.alt|default(post.title, true),
+                        'absolute inset-0 w-full h-full object-cover bg-gray-200 dark:bg-gray-700',
+                        'eager',
+                    ) }}
                 {% endif %}
             </div>
         </div>

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -8,13 +8,13 @@
             <div class="aspect-[21/9] relative">
                 {% if post.thumbnail %}
                     {{ responsive.render(
-                        post.thumbnail.src,
-                        928,
-                        928 / 21 * 9,
-                        '(min-width: 960px) 928px, (min-width: 768px) calc(100vw - 2rem), 100vw',
-                        post.thumbnail.alt|default(post.title, true),
-                        'absolute inset-0 w-full h-full object-cover bg-gray-200 dark:bg-gray-700',
-                        'eager',
+                        src: post.thumbnail.src,
+                        width: 928,
+                        height: 928 / 21 * 9,
+                        sizes: '(min-width: 960px) 928px, (min-width: 768px) calc(100vw - 2rem), 100vw',
+                        alt: post.thumbnail.alt|default(post.title, true),
+                        class: 'absolute inset-0 w-full h-full object-cover bg-gray-200 dark:bg-gray-700',
+                        loading: 'eager',
                     ) }}
                 {% endif %}
             </div>

--- a/templates/single-fragment.twig
+++ b/templates/single-fragment.twig
@@ -46,7 +46,7 @@
                                     width: 128,
                                     height: 72,
                                     sizes: '128px',
-                                    alt: post.thumbnail.alt|default(post.title, true),
+                                    alt: post.thumbnail.alt|default(post.title),
                                     class: 'w-full',
                                 ) }}
                             </div>

--- a/templates/single-fragment.twig
+++ b/templates/single-fragment.twig
@@ -1,6 +1,8 @@
 {% extends 'base.twig' %}
 
 {% block content %}
+    {% import 'partial/responsive-image.twig' as responsive %}
+
     <article id="post-{{ post.id }}" class="{{ post.class }}">
         <div class="w-full mx-auto lg:max-w-960 lg:pt-12 lg:mb-12">
             {{ embed }}
@@ -39,9 +41,14 @@
                     {% for post in posts %}
                         <a class="flex py-2 hover:bg-gray-50 dark:hover:bg-gray-700" href="{{ post.link }}">
                             <div class="flex-none w-32 relative">
-                                <img alt="{{ post.thumbnail.alt }}"
-                                     class="w-full" src="{{ post.thumbnail.src|imgproxy(160, 90) }}"
-                                     srcset="{{ post.thumbnail.src|imgproxy(320, 180) }} 2x"/>
+                                {{ responsive.render(
+                                    post.thumbnail.src,
+                                    128,
+                                    72,
+                                    '128px',
+                                    post.thumbnail.alt|default(post.title, true),
+                                    'w-full',
+                                ) }}
                             </div>
                             <div class="flex-auto pl-4">
                                 <h2 class="text-xl font-semibold text-black dark:text-white">{{ post.title }}</h2>

--- a/templates/single-fragment.twig
+++ b/templates/single-fragment.twig
@@ -42,12 +42,12 @@
                         <a class="flex py-2 hover:bg-gray-50 dark:hover:bg-gray-700" href="{{ post.link }}">
                             <div class="flex-none w-32 relative">
                                 {{ responsive.render(
-                                    post.thumbnail.src,
-                                    128,
-                                    72,
-                                    '128px',
-                                    post.thumbnail.alt|default(post.title, true),
-                                    'w-full',
+                                    src: post.thumbnail.src,
+                                    width: 128,
+                                    height: 72,
+                                    sizes: '128px',
+                                    alt: post.thumbnail.alt|default(post.title, true),
+                                    class: 'w-full',
                                 ) }}
                             </div>
                             <div class="flex-auto pl-4">

--- a/templates/single-tv.twig
+++ b/templates/single-tv.twig
@@ -1,12 +1,20 @@
 {% extends 'base.twig' %}
 
 {% block content %}
+    {% import 'partial/responsive-image.twig' as responsive %}
+
     <article id="post-{{ post.id }}" class="{{ post.class }}">
         <div class="px-6 md:px-12 max-w-3xl mx-auto py-8 md:pt-16">
             {% if post.thumbnail %}
-                <img src="{{ post.thumbnail.src|imgproxy(960, 540) }}"
-                     srcset="{{ post.thumbnail.src|imgproxy(1920, 1080) }} 2x"
-                     alt="{{ post.title }}" width="960" height="540" class="w-full">
+                {{ responsive.render(
+                    post.thumbnail.src,
+                    720,
+                    405,
+                    '(min-width: 768px) 672px, calc(100vw - 3rem)',
+                    post.thumbnail.alt|default(post.title, true),
+                    'w-full',
+                    'eager',
+                ) }}
             {% endif %}
 
             <h1 class="font-black font-round text-4xl md:text-5xl uppercase text-black dark:text-white">{{ post.title }}</h1>
@@ -31,10 +39,14 @@
                                 <article>
                                     <a href="?v={{ video.id }}">
                                         {% set width = 220 %}
-                                        <img class="w-full object-contain" loading="lazy" alt="{{ video.name }}"
-                                             width="{{ width }}" height="{{ (width / 16 * 9)|round }}"
-                                             src="{{ video.thumbnail|imgproxy(width, width / 16 * 9) }}"
-                                             srcset="{{ video.thumbnail|imgproxy(width * 2, (width * 2) / 16 * 9) }} 2x"/>
+                                        {{ responsive.render(
+                                            video.thumbnail,
+                                            width,
+                                            width / 16 * 9,
+                                            '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), calc((100vw - 3rem) / 2)',
+                                            video.name,
+                                            'w-full object-contain',
+                                        ) }}
                                         <h3 class="font-bold mt-2 :text-gray-200">{{ video.name }}</h3>
                                     </a>
                                 </article>

--- a/templates/single-tv.twig
+++ b/templates/single-tv.twig
@@ -7,13 +7,13 @@
         <div class="px-6 md:px-12 max-w-3xl mx-auto py-8 md:pt-16">
             {% if post.thumbnail %}
                 {{ responsive.render(
-                    post.thumbnail.src,
-                    720,
-                    405,
-                    '(min-width: 768px) 672px, calc(100vw - 3rem)',
-                    post.thumbnail.alt|default(post.title, true),
-                    'w-full',
-                    'eager',
+                    src: post.thumbnail.src,
+                    width: 720,
+                    height: 405,
+                    sizes: '(min-width: 768px) 672px, calc(100vw - 3rem)',
+                    alt: post.thumbnail.alt|default(post.title, true),
+                    class: 'w-full',
+                    loading: 'eager',
                 ) }}
             {% endif %}
 
@@ -40,12 +40,12 @@
                                     <a href="?v={{ video.id }}">
                                         {% set width = 220 %}
                                         {{ responsive.render(
-                                            video.thumbnail,
-                                            width,
-                                            width / 16 * 9,
-                                            '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), calc((100vw - 3rem) / 2)',
-                                            video.name,
-                                            'w-full object-contain',
+                                            src: video.thumbnail,
+                                            width: width,
+                                            height: width / 16 * 9,
+                                            sizes: '(min-width: 960px) 220px, (min-width: 768px) calc((100vw - 5rem) / 4), calc((100vw - 3rem) / 2)',
+                                            alt: video.name,
+                                            class: 'w-full object-contain',
                                         ) }}
                                         <h3 class="font-bold mt-2 :text-gray-200">{{ video.name }}</h3>
                                     </a>

--- a/templates/single-tv.twig
+++ b/templates/single-tv.twig
@@ -11,7 +11,7 @@
                     width: 720,
                     height: 405,
                     sizes: '(min-width: 768px) 672px, calc(100vw - 3rem)',
-                    alt: post.thumbnail.alt|default(post.title, true),
+                    alt: post.thumbnail.alt|default(post.title),
                     class: 'w-full',
                     loading: 'eager',
                 ) }}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -22,13 +22,13 @@
                 {% elseif post.thumbnail %}
                     <div class="w-full mx-auto max-w-960">
                         {{ responsive.render(
-                            post.thumbnail.src,
-                            960,
-                            540,
-                            '(min-width: 960px) 960px, 100vw',
-                            post.thumbnail.alt|default(post.title, true),
-                            'w-full',
-                            'eager',
+                            src: post.thumbnail.src,
+                            width: 960,
+                            height: 540,
+                            sizes: '(min-width: 960px) 960px, 100vw',
+                            alt: post.thumbnail.alt|default(post.title, true),
+                            class: 'w-full',
+                            loading: 'eager',
                         ) }}
                         {% if post.thumbnail.caption %}
                             <p class="text-sm text-gray-500 dark:text-gray-400 text-center pt-2">{{ post.thumbnail.caption }}</p>

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -26,7 +26,7 @@
                             width: 960,
                             height: 540,
                             sizes: '(min-width: 960px) 960px, 100vw',
-                            alt: post.thumbnail.alt|default(post.title, true),
+                            alt: post.thumbnail.alt|default(post.title),
                             class: 'w-full',
                             loading: 'eager',
                         ) }}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -1,6 +1,8 @@
 {% extends 'base.twig' %}
 
 {% block content %}
+    {% import 'partial/responsive-image.twig' as responsive %}
+
     <article id="post-{{ post.id }}" class="{{ post.class }}">
         <div class="grid grid-cols-1">
             <div class="row-start-2 md:row-start-auto">
@@ -19,9 +21,15 @@
                     </div>
                 {% elseif post.thumbnail %}
                     <div class="w-full mx-auto max-w-960">
-                        <img src="{{ post.thumbnail.src|imgproxy(960, 540) }}"
-                             srcset="{{ post.thumbnail.src|imgproxy(1920, 1080) }} 2x"
-                             alt="{{ post.thumbnail.alt }}" width="1920" height="1080" class="w-full">
+                        {{ responsive.render(
+                            post.thumbnail.src,
+                            960,
+                            540,
+                            '(min-width: 960px) 960px, 100vw',
+                            post.thumbnail.alt|default(post.title, true),
+                            'w-full',
+                            'eager',
+                        ) }}
                         {% if post.thumbnail.caption %}
                             <p class="text-sm text-gray-500 dark:text-gray-400 text-center pt-2">{{ post.thumbnail.caption }}</p>
                         {% endif %}


### PR DESCRIPTION
## Wat is gedaan

- Gedeelde `Streekomroep\ResponsiveImage` helper toegevoegd voor width-descriptor `srcset` kandidaten via de bestaande `zw_imgproxy()` pipeline.
- Gedeelde Twig macro `templates/partial/responsive-image.twig` toegevoegd voor consistente `<img>` en `<source>` markup.
- Gallery-implementatie aangepast zodat gallery en theme-content dezelfde responsive-image helper gebruiken.
- Content-afbeeldingen uit issue #191 gemigreerd naar `srcset` met `w` descriptors plus layout-specifieke `sizes`.
- Alle gemigreerde `<img>` tags voorzien van `width`, `height`, `loading` en `decoding`.
- `<picture>` art-direction in `post-thumbnail-4-3.twig` behouden en alleen responsive source/img attributen toegevoegd.
- Avatars en video `poster` attributen bewust ongemoeid gelaten, conform scope van de issue.
- Extra kleine codekwaliteit: footer-site-icoon heeft nu ook native responsive attrs en vaste afmetingen.

## Checklist issue #191

- [x] Geen content `<img>` zonder `srcset` meer, buiten expliciet out-of-scope avatars/video posters.
- [x] Viewport-schalende content images gebruiken width-descriptor `srcset` + `sizes` in plaats van vaste `1x/2x` descriptors.
- [x] Gemigreerde `<img>` tags zetten `width`/`height` voor CLS.
- [x] Gemigreerde `<img>` tags zetten `loading` en `decoding`.
- [x] Kleine vaste UI avatars blijven op hun bestaande density descriptors.
- [x] Een gedeelde helper/macro ondersteunt de migratie en hergebruikt het gallery-patroon uit #180.
- [x] Extra gemiste content-thumbnail in `templates/partial/tile.twig` meegenomen, omdat de acceptance letterlijk over content `<img>` zonder `srcset` gaat.

## Fact-check

- Issue #191 stond nog open en de acceptance criteria matchten nog met de codebase.
- Twee issue-regelrefs waren verouderd: `blok_dossiers_carrousel.twig:60` en `single-tv.twig:40`; de actuele locaties zijn opnieuw getraceerd voor de wijziging.
- MDN bevestigt dat `w` descriptors in `srcset` met `sizes` gebruikt worden zodat browsers de juiste kandidaat kiezen voor slotbreedte, viewport en device pixel ratio.

Bronnen:
- https://github.com/oszuidwest/streekomroep-wp/issues/191
- https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes

Closes #191

## Validatie

- [x] `composer lint:twig`
- [x] `vendor/bin/phpcs --standard=phpcs.xml .` groen; bestaande WPCS deprecated sniff warning blijft zichtbaar.
- [x] `git diff --check`
- [x] Statische Twig `<img>` audit: alle niet-avatar/niet-poster afbeeldingen hebben `srcset`, `sizes`, `width`, `height`, `loading` en `decoding`.
- [x] Docker/WP-CLI helper-check: `Streekomroep\ResponsiveImage::srcset()` genereert `192w`, base en `2x base` kandidaten via imgproxy.
- [x] Docker smoke checks: `/`, `/sample-page/`, `/native-gallery-bewijs/`, `/category/uncategorized/`, `/author/admin/` en `/?s=hello` geven 200 zonder PHP error markers.
- [x] GitHub Actions groen voor deploy en PHPCS 8.3/8.4.

Note: `composer validate --strict` blijft non-zero door het bestaande ontbrekende `license` veld in `composer.json`; dat is package-metadata buiten deze fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rolled out consistent responsive image rendering across galleries, top stories, dossiers, TV pages, articles, carousels, and related tiles using shared rendering.
* **Bug Fixes**
  * Improved video handling: missing/empty thumbnails no longer break thumbnail or social image generation; social image logic now safely falls back when no valid image exists.
* **Accessibility & Performance**
  * Thumbnails and key icons now include explicit width/height, `decoding="async"`, improved responsive `sizes`/`srcset`, and better `alt` fallbacks, with context-aware eager vs. lazy loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->