### PR TITLE
Shared scroller partial for horizontal carousels

### DIFF
--- a/single.php
+++ b/single.php
@@ -251,17 +251,6 @@ if ($timber_post->post_type == 'fm') {
         }
     }
     $context['schedule_days'] = $activeDays;
-
-    $context['other_shows'] = Timber::get_posts([
-        'post_type' => 'fm',
-        'posts_per_page' => -1,
-        'post__not_in' => [$show->ID],
-        'ignore_sticky_posts' => true,
-        'meta_key' => 'fm_show_actief',
-        'meta_value' => '1',
-        'orderby' => 'title',
-        'order' => 'ASC',
-    ]);
 }
 
 if ($timber_post->post_gekoppeld_fragment) {

--- a/single.php
+++ b/single.php
@@ -192,7 +192,7 @@ if ($timber_post->post_type == 'fm') {
         return $rhs <=> $lhs;
     });
 
-    // Group recordings per day, then per ISO week (newest week first)
+    // Group recordings per day (newest first), shown 5 days at a time
     $recordingDays = [];
     foreach ($recordings as $recording) {
         $key = $recording->toDateString();
@@ -202,15 +202,11 @@ if ($timber_post->post_type == 'fm') {
         $recordingDays[$key]['times'][] = $recording;
     }
 
-    $recordingWeeks = [];
-    foreach ($recordingDays as $day) {
-        $recordingWeeks[$day['date']->isoWeekYear . '-' . $day['date']->isoWeek][] = $day;
-    }
-    $recordingWeeks = array_values($recordingWeeks);
+    $recordingPages = array_chunk(array_values($recordingDays), 5);
 
-    $week = isset($_GET['week']) ? absint($_GET['week']) : 0;
-    if ($week >= count($recordingWeeks)) {
-        $week = max(0, count($recordingWeeks) - 1);
+    $page = isset($_GET['gemist']) ? absint($_GET['gemist']) : 0;
+    if ($page >= count($recordingPages)) {
+        $page = max(0, count($recordingPages) - 1);
     }
 
     $retention = (int)get_field('radio_gemist_retentie', 'option');
@@ -225,10 +221,9 @@ if ($timber_post->post_type == 'fm') {
     }
 
     $context['gemist'] = [
-        'weeks' => count($recordingWeeks),
-        'week' => $week,
-        'days' => $recordingWeeks[$week] ?? [],
-        'newest_is_recent' => !empty($recordings) && ($recordings[0]->isToday() || $recordings[0]->isYesterday()),
+        'pages' => count($recordingPages),
+        'page' => $page,
+        'days' => $recordingPages[$page] ?? [],
         'retention_label' => $retentionLabel,
     ];
 

--- a/single.php
+++ b/single.php
@@ -149,17 +149,16 @@ if ($timber_post->post_type == 'tv') {
 
 if ($timber_post->post_type == 'fm') {
     $show = $timber_post;
-    $gemist = (bool)$show->meta('fm_show_actief') && (bool)get_field('radio_gemist_actief', 'option');
+    $active = (bool)$show->meta('fm_show_actief');
+    $gemist = $active && (bool)get_field('radio_gemist_actief', 'option');
 
-    $rules = $show->meta('fm_show_programmatie');
-    if (!$rules) {
-        $rules = [];
-    }
+    $rules = $show->meta('fm_show_programmatie') ?: [];
+    $retention = (int)get_field('radio_gemist_retentie', 'option');
 
     $recordings = [];
     if ($gemist) {
         $hour = Carbon::now('Europe/Amsterdam')->startOfHour()->subHour();
-        $end = $hour->copy()->subDays(get_field('radio_gemist_retentie', 'option'));
+        $end = $hour->copy()->subDays($retention);
 
         while ($hour->isAfter($end)) {
             $dayname = BroadcastDay::WEEKDAY_NAMES[$hour->dayOfWeekIso];
@@ -192,8 +191,8 @@ if ($timber_post->post_type == 'fm') {
         return $rhs <=> $lhs;
     });
 
-    // Group recordings per day (newest first); the template pages through
-    // them client-side, 5 days at a time
+    // Group recordings per day (newest first); the template shows them in a
+    // horizontally scrolling carousel
     $recordingDays = [];
     foreach ($recordings as $recording) {
         $key = $recording->toDateString();
@@ -203,15 +202,10 @@ if ($timber_post->post_type == 'fm') {
         $recordingDays[$key]['times'][] = $recording;
     }
 
-    $retention = (int)get_field('radio_gemist_retentie', 'option');
     $retentionLabel = null;
-    if ($retention > 0 && !empty($recordings)) {
-        if ($retention % 7 === 0) {
-            $weeks = intdiv($retention, 7);
-            $retentionLabel = $weeks === 1 ? '1 week' : $weeks . ' weken';
-        } else {
-            $retentionLabel = $retention === 1 ? '1 dag' : $retention . ' dagen';
-        }
+    if ($retention > 0 && $recordings) {
+        $weeks = intdiv($retention, 7);
+        $retentionLabel = $retention % 7 === 0 ? ($weeks === 1 ? '1 week' : $weeks . ' weken') : ($retention === 1 ? '1 dag' : $retention . ' dagen');
     }
 
     $context['gemist'] = [
@@ -219,43 +213,23 @@ if ($timber_post->post_type == 'fm') {
         'retention_label' => $retentionLabel,
     ];
 
-    // Find the next moment this show is live, to derive what airs directly after it
-    $schedule = new \Streekomroep\BroadcastSchedule();
-    $now = Carbon::now(wp_timezone());
-    $nextLive = null;
-    foreach ($schedule->days as $day) {
-        foreach ($day->radio as $broadcast) {
-            if ($broadcast->show && $broadcast->show->ID == $show->ID && $broadcast->start->isAfter($now)) {
-                $nextLive = $broadcast;
-                break 2;
-            }
-        }
-    }
+    // What airs directly after this show's next live broadcast; only shows with
+    // active programmatie rules appear in the schedule, so skip building it otherwise
     $followingShow = null;
-    if ($nextLive) {
-        foreach ($schedule->days as $day) {
-            foreach ($day->radio as $broadcast) {
-                if ($broadcast->start->equalTo($nextLive->end)) {
-                    $followingShow = $broadcast;
-                    break 2;
-                }
-            }
+    if ($active && $rules) {
+        $schedule = new \Streekomroep\BroadcastSchedule();
+        $nextLive = $schedule->getNextBroadcastOfShow($show->ID);
+        if ($nextLive) {
+            $followingShow = $schedule->getNextRadioBroadcast($nextLive);
         }
     }
     $context['following_show'] = $followingShow;
 
-    $activeDays = [];
-    foreach ($rules as $rule) {
-        foreach ($rule['fm_show_dagen'] as $dayname) {
-            $activeDays[] = $dayname;
-        }
-    }
-    $context['schedule_days'] = $activeDays;
+    $context['programmatie'] = $rules;
+    $context['schedule_days'] = array_merge(...array_column($rules, 'fm_show_dagen'));
+    $context['weekday_names'] = array_values(BroadcastDay::WEEKDAY_NAMES);
 
-    $yoastTitles = get_option('wpseo_titles');
-    $context['breadcrumb_separator'] = is_array($yoastTitles) && !empty($yoastTitles['breadcrumbs-sep'])
-        ? $yoastTitles['breadcrumbs-sep']
-        : '/';
+    $context['breadcrumb_separator'] = class_exists('WPSEO_Options') ? WPSEO_Options::get('breadcrumbs-sep', '/') : '/';
 }
 
 if ($timber_post->post_gekoppeld_fragment) {

--- a/single.php
+++ b/single.php
@@ -149,16 +149,15 @@ if ($timber_post->post_type == 'tv') {
 
 if ($timber_post->post_type == 'fm') {
     $show = $timber_post;
-    $gemist = (bool)$show->meta('fm_show_actief');
+    $gemist = (bool)$show->meta('fm_show_actief') && (bool)get_field('radio_gemist_actief', 'option');
+
+    $rules = $show->meta('fm_show_programmatie');
+    if (!$rules) {
+        $rules = [];
+    }
 
     $recordings = [];
     if ($gemist) {
-        $items = [];
-        $rules = $show->meta('fm_show_programmatie');
-        if (!$rules) {
-            $rules = [];
-        }
-
         $hour = Carbon::now('Europe/Amsterdam')->startOfHour()->subHour();
         $end = $hour->copy()->subDays(get_field('radio_gemist_retentie', 'option'));
 
@@ -193,7 +192,91 @@ if ($timber_post->post_type == 'fm') {
         return $rhs <=> $lhs;
     });
 
-    $context['recordings'] = $recordings;
+    // Group recordings per day, then per ISO week (newest week first)
+    $recordingDays = [];
+    foreach ($recordings as $recording) {
+        $key = $recording->toDateString();
+        if (!isset($recordingDays[$key])) {
+            $recordingDays[$key] = ['date' => $recording->copy()->startOfDay(), 'times' => []];
+        }
+        $recordingDays[$key]['times'][] = $recording;
+    }
+
+    $recordingWeeks = [];
+    foreach ($recordingDays as $day) {
+        $recordingWeeks[$day['date']->isoWeekYear . '-' . $day['date']->isoWeek][] = $day;
+    }
+    $recordingWeeks = array_values($recordingWeeks);
+
+    $week = isset($_GET['week']) ? absint($_GET['week']) : 0;
+    if ($week >= count($recordingWeeks)) {
+        $week = max(0, count($recordingWeeks) - 1);
+    }
+
+    $retention = (int)get_field('radio_gemist_retentie', 'option');
+    $retentionLabel = null;
+    if ($retention > 0 && !empty($recordings)) {
+        if ($retention % 7 === 0) {
+            $weeks = intdiv($retention, 7);
+            $retentionLabel = $weeks === 1 ? '1 week' : $weeks . ' weken';
+        } else {
+            $retentionLabel = $retention === 1 ? '1 dag' : $retention . ' dagen';
+        }
+    }
+
+    $context['gemist'] = [
+        'weeks' => count($recordingWeeks),
+        'week' => $week,
+        'days' => $recordingWeeks[$week] ?? [],
+        'newest_is_recent' => !empty($recordings) && ($recordings[0]->isToday() || $recordings[0]->isYesterday()),
+        'retention_label' => $retentionLabel,
+    ];
+
+    // Find the next moment this show is live, to derive what airs directly after it
+    $schedule = new \Streekomroep\BroadcastSchedule();
+    $now = Carbon::now(wp_timezone());
+    $nextLive = null;
+    foreach ($schedule->days as $day) {
+        foreach ($day->radio as $broadcast) {
+            if ($broadcast->show && $broadcast->show->ID == $show->ID && $broadcast->start->isAfter($now)) {
+                $nextLive = $broadcast;
+                break 2;
+            }
+        }
+    }
+    $followingShow = null;
+    if ($nextLive) {
+        foreach ($schedule->days as $day) {
+            foreach ($day->radio as $broadcast) {
+                if ($broadcast->start->equalTo($nextLive->end)) {
+                    $followingShow = $broadcast;
+                    break 2;
+                }
+            }
+        }
+    }
+    $context['following_show'] = $followingShow;
+
+    $activeDays = [];
+    foreach ($rules as $rule) {
+        foreach ($rule['fm_show_dagen'] as $dayname) {
+            $activeDays[] = $dayname;
+        }
+    }
+    $context['schedule_days'] = $activeDays;
+
+    $context['fm_player_page'] = zw_get_page_by_template('wp-page-fm-player.php');
+
+    $context['other_shows'] = Timber::get_posts([
+        'post_type' => 'fm',
+        'posts_per_page' => -1,
+        'post__not_in' => [$show->ID],
+        'ignore_sticky_posts' => true,
+        'meta_key' => 'fm_show_actief',
+        'meta_value' => '1',
+        'orderby' => 'title',
+        'order' => 'ASC',
+    ]);
 }
 
 if ($timber_post->post_gekoppeld_fragment) {

--- a/single.php
+++ b/single.php
@@ -260,8 +260,6 @@ if ($timber_post->post_type == 'fm') {
     }
     $context['schedule_days'] = $activeDays;
 
-    $context['fm_player_page'] = zw_get_page_by_template('wp-page-fm-player.php');
-
     $context['other_shows'] = Timber::get_posts([
         'post_type' => 'fm',
         'posts_per_page' => -1,

--- a/single.php
+++ b/single.php
@@ -192,7 +192,8 @@ if ($timber_post->post_type == 'fm') {
         return $rhs <=> $lhs;
     });
 
-    // Group recordings per day (newest first), shown 5 days at a time
+    // Group recordings per day (newest first); the template pages through
+    // them client-side, 5 days at a time
     $recordingDays = [];
     foreach ($recordings as $recording) {
         $key = $recording->toDateString();
@@ -200,13 +201,6 @@ if ($timber_post->post_type == 'fm') {
             $recordingDays[$key] = ['date' => $recording->copy()->startOfDay(), 'times' => []];
         }
         $recordingDays[$key]['times'][] = $recording;
-    }
-
-    $recordingPages = array_chunk(array_values($recordingDays), 5);
-
-    $page = isset($_GET['gemist']) ? absint($_GET['gemist']) : 0;
-    if ($page >= count($recordingPages)) {
-        $page = max(0, count($recordingPages) - 1);
     }
 
     $retention = (int)get_field('radio_gemist_retentie', 'option');
@@ -221,9 +215,7 @@ if ($timber_post->post_type == 'fm') {
     }
 
     $context['gemist'] = [
-        'pages' => count($recordingPages),
-        'page' => $page,
-        'days' => $recordingPages[$page] ?? [],
+        'days' => array_values($recordingDays),
         'retention_label' => $retentionLabel,
     ];
 

--- a/single.php
+++ b/single.php
@@ -251,6 +251,11 @@ if ($timber_post->post_type == 'fm') {
         }
     }
     $context['schedule_days'] = $activeDays;
+
+    $yoastTitles = get_option('wpseo_titles');
+    $context['breadcrumb_separator'] = is_array($yoastTitles) && !empty($yoastTitles['breadcrumbs-sep'])
+        ? $yoastTitles['breadcrumbs-sep']
+        : '/';
 }
 
 if ($timber_post->post_gekoppeld_fragment) {

--- a/src/BroadcastSchedule.php
+++ b/src/BroadcastSchedule.php
@@ -146,9 +146,9 @@ class BroadcastSchedule
         return $this->days[$format];
     }
 
-    public function getNextRadioBroadcast()
+    public function getNextRadioBroadcast(?RadioBroadcast $after = null)
     {
-        $current = $this->getCurrentRadioBroadcast();
+        $after = $after ?: $this->getCurrentRadioBroadcast();
         $returnNext = false;
 
         foreach ($this->days as $day) {
@@ -157,8 +157,23 @@ class BroadcastSchedule
                     return $broadcast;
                 }
 
-                if ($broadcast == $current) {
+                if ($broadcast == $after) {
                     $returnNext = true;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function getNextBroadcastOfShow(int $showId)
+    {
+        $now = Carbon::now(wp_timezone());
+
+        foreach ($this->days as $day) {
+            foreach ($day->radio as $broadcast) {
+                if ($broadcast->show && $broadcast->show->ID == $showId && $broadcast->start->isAfter($now)) {
+                    return $broadcast;
                 }
             }
         }

--- a/src/Site.php
+++ b/src/Site.php
@@ -125,6 +125,69 @@ class Site extends \Timber\Site
         return sprintf('Elke %s van %d tot %d uur', $dayString, $entry['fm_show_starttijd'], $entry['fm_show_eindtijd']);
     }
 
+    /**
+     * Format a programmatie rule as a short label, e.g. "ma t/m vr · 07:00–09:00".
+     */
+    public function format_schedule_compact($entry)
+    {
+        $abbreviations = [
+            'maandag' => 'ma',
+            'dinsdag' => 'di',
+            'woensdag' => 'wo',
+            'donderdag' => 'do',
+            'vrijdag' => 'vr',
+            'zaterdag' => 'za',
+            'zondag' => 'zo',
+        ];
+
+        $days = array_values(array_intersect(array_keys($abbreviations), $entry['fm_show_dagen'] ?: []));
+
+        if (count($days) === 7) {
+            $dayString = 'elke dag';
+        } else {
+            $positions = array_flip(array_keys($abbreviations));
+
+            // Split the selected days into runs of consecutive weekdays
+            $runs = [];
+            $run = [];
+            foreach ($days as $day) {
+                if ($run && $positions[$day] !== $positions[end($run)] + 1) {
+                    $runs[] = $run;
+                    $run = [];
+                }
+                $run[] = $day;
+            }
+            if ($run) {
+                $runs[] = $run;
+            }
+
+            $parts = [];
+            foreach ($runs as $run) {
+                if (count($run) >= 3) {
+                    $parts[] = $abbreviations[$run[0]] . ' t/m ' . $abbreviations[end($run)];
+                } else {
+                    foreach ($run as $day) {
+                        $parts[] = $abbreviations[$day];
+                    }
+                }
+            }
+
+            $dayString = implode(', ', $parts);
+        }
+
+        if (empty($entry['fm_show_starttijd']) || empty($entry['fm_show_eindtijd'])) {
+            return $dayString;
+        }
+
+        $time = substr($entry['fm_show_starttijd'], 0, 5) . '–' . substr($entry['fm_show_eindtijd'], 0, 5);
+
+        if ($dayString === '') {
+            return $time;
+        }
+
+        return $dayString . ' · ' . $time;
+    }
+
     public function get_icon($name)
     {
         static $cache = [];
@@ -165,6 +228,7 @@ class Site extends \Timber\Site
         });
 
         $twig->addFilter(new \Twig\TwigFilter('format_schedule', [$this, 'format_schedule']));
+        $twig->addFilter(new \Twig\TwigFilter('format_schedule_compact', [$this, 'format_schedule_compact']));
         $twig->addFunction(new \Twig\TwigFunction('icon', [$this, 'get_icon']));
         $twig->addFunction(new \Twig\TwigFunction('responsive_image_srcset', [ResponsiveImage::class, 'srcset']));
         $twig->addFilter(new \Twig\TwigFilter('imgproxy', [$this, 'imgproxy']));

--- a/src/Site.php
+++ b/src/Site.php
@@ -126,24 +126,24 @@ class Site extends \Timber\Site
     }
 
     /**
-     * Format a programmatie rule as a short label, e.g. "ma t/m vr · 07:00–09:00".
+     * Format a programmatie rule as a short label, e.g. "MA T/M VR van 07:00 tot 09:00 uur".
      */
     public function format_schedule_compact($entry)
     {
         $abbreviations = [
-            'maandag' => 'ma',
-            'dinsdag' => 'di',
-            'woensdag' => 'wo',
-            'donderdag' => 'do',
-            'vrijdag' => 'vr',
-            'zaterdag' => 'za',
-            'zondag' => 'zo',
+            'maandag' => 'MA',
+            'dinsdag' => 'DI',
+            'woensdag' => 'WO',
+            'donderdag' => 'DO',
+            'vrijdag' => 'VR',
+            'zaterdag' => 'ZA',
+            'zondag' => 'ZO',
         ];
 
         $days = array_values(array_intersect(array_keys($abbreviations), $entry['fm_show_dagen'] ?: []));
 
         if (count($days) === 7) {
-            $dayString = 'elke dag';
+            $dayString = 'ELKE DAG';
         } else {
             $positions = array_flip(array_keys($abbreviations));
 
@@ -164,7 +164,7 @@ class Site extends \Timber\Site
             $parts = [];
             foreach ($runs as $run) {
                 if (count($run) >= 3) {
-                    $parts[] = $abbreviations[$run[0]] . ' t/m ' . $abbreviations[end($run)];
+                    $parts[] = $abbreviations[$run[0]] . ' T/M ' . $abbreviations[end($run)];
                 } else {
                     foreach ($run as $day) {
                         $parts[] = $abbreviations[$day];
@@ -179,13 +179,13 @@ class Site extends \Timber\Site
             return $dayString;
         }
 
-        $time = substr($entry['fm_show_starttijd'], 0, 5) . '–' . substr($entry['fm_show_eindtijd'], 0, 5);
+        $time = 'van ' . substr($entry['fm_show_starttijd'], 0, 5) . ' tot ' . substr($entry['fm_show_eindtijd'], 0, 5) . ' uur';
 
         if ($dayString === '') {
-            return $time;
+            return ucfirst($time);
         }
 
-        return $dayString . ' · ' . $time;
+        return $dayString . ' ' . $time;
     }
 
     public function get_icon($name)

--- a/src/Site.php
+++ b/src/Site.php
@@ -110,71 +110,27 @@ class Site extends \Timber\Site
         add_theme_support('custom-logo');
     }
 
-    public function format_schedule($entry)
-    {
-        $days = $entry['fm_show_dagen'];
-        if (empty($days)) {
-            $dayString = '';
-        } elseif (count($days) === 1) {
-            $dayString = $days[0];
-        } else {
-            $lastDay = array_pop($days);
-            $dayString = implode(', ', $days) . ' en ' . $lastDay;
-        }
-
-        return sprintf('Elke %s van %d tot %d uur', $dayString, $entry['fm_show_starttijd'], $entry['fm_show_eindtijd']);
-    }
-
     /**
      * Format a programmatie rule as a short label, e.g. "MA T/M VR van 07:00 tot 09:00 uur".
      */
     public function format_schedule_compact($entry)
     {
-        $abbreviations = [
-            'maandag' => 'MA',
-            'dinsdag' => 'DI',
-            'woensdag' => 'WO',
-            'donderdag' => 'DO',
-            'vrijdag' => 'VR',
-            'zaterdag' => 'ZA',
-            'zondag' => 'ZO',
-        ];
+        $names = array_values(BroadcastDay::WEEKDAY_NAMES);
+        $abbreviate = fn ($day) => strtoupper(substr($day, 0, 2));
 
-        $days = array_values(array_intersect(array_keys($abbreviations), $entry['fm_show_dagen'] ?: []));
+        $days = array_values(array_intersect($names, $entry['fm_show_dagen'] ?: []));
+
+        $positions = array_flip($names);
+        $contiguous = $days && $positions[end($days)] - $positions[$days[0]] === count($days) - 1;
 
         if (count($days) === 7) {
             $dayString = 'ELKE DAG';
-        } elseif ($days === ['maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag']) {
+        } elseif ($days === array_slice($names, 0, 5)) {
             $dayString = 'ELKE WERKDAG';
+        } elseif (count($days) >= 3 && $contiguous) {
+            $dayString = $abbreviate($days[0]) . ' T/M ' . $abbreviate(end($days));
         } else {
-            $positions = array_flip(array_keys($abbreviations));
-
-            // Split the selected days into runs of consecutive weekdays
-            $runs = [];
-            $run = [];
-            foreach ($days as $day) {
-                if ($run && $positions[$day] !== $positions[end($run)] + 1) {
-                    $runs[] = $run;
-                    $run = [];
-                }
-                $run[] = $day;
-            }
-            if ($run) {
-                $runs[] = $run;
-            }
-
-            $parts = [];
-            foreach ($runs as $run) {
-                if (count($run) >= 3) {
-                    $parts[] = $abbreviations[$run[0]] . ' T/M ' . $abbreviations[end($run)];
-                } else {
-                    foreach ($run as $day) {
-                        $parts[] = $abbreviations[$day];
-                    }
-                }
-            }
-
-            $dayString = implode(', ', $parts);
+            $dayString = implode(', ', array_map($abbreviate, $days));
         }
 
         if (empty($entry['fm_show_starttijd']) || empty($entry['fm_show_eindtijd'])) {
@@ -183,11 +139,7 @@ class Site extends \Timber\Site
 
         $time = 'van ' . substr($entry['fm_show_starttijd'], 0, 5) . ' tot ' . substr($entry['fm_show_eindtijd'], 0, 5) . ' uur';
 
-        if ($dayString === '') {
-            return ucfirst($time);
-        }
-
-        return $dayString . ' ' . $time;
+        return trim($dayString . ' ' . $time);
     }
 
     public function get_icon($name)
@@ -229,7 +181,6 @@ class Site extends \Timber\Site
             }
         });
 
-        $twig->addFilter(new \Twig\TwigFilter('format_schedule', [$this, 'format_schedule']));
         $twig->addFilter(new \Twig\TwigFilter('format_schedule_compact', [$this, 'format_schedule_compact']));
         $twig->addFunction(new \Twig\TwigFunction('icon', [$this, 'get_icon']));
         $twig->addFunction(new \Twig\TwigFunction('responsive_image_srcset', [ResponsiveImage::class, 'srcset']));

--- a/src/Site.php
+++ b/src/Site.php
@@ -144,6 +144,8 @@ class Site extends \Timber\Site
 
         if (count($days) === 7) {
             $dayString = 'ELKE DAG';
+        } elseif ($days === ['maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag']) {
+            $dayString = 'ELKE WERKDAG';
         } else {
             $positions = array_flip(array_keys($abbreviations));
 

--- a/streekomroep-acf-json/group_5f21b1dcb2dc2.json
+++ b/streekomroep-acf-json/group_5f21b1dcb2dc2.json
@@ -42,6 +42,50 @@
             "return_format": "id"
         },
         {
+            "key": "field_6878a1c2f4b09",
+            "label": "Rubrieken",
+            "name": "fm_show_rubrieken",
+            "aria-label": "",
+            "type": "repeater",
+            "instructions": "Vaste onderdelen van het programma (bijvoorbeeld een top 3 of een dagelijkse vraag). Worden als labels op de programmapagina getoond.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "collapsed": "",
+            "min": 0,
+            "max": 0,
+            "layout": "table",
+            "button_label": "Nieuwe rubriek",
+            "sub_fields": [
+                {
+                    "key": "field_6878a1c2f4b0a",
+                    "label": "Naam",
+                    "name": "fm_show_rubriek_naam",
+                    "aria-label": "",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 1,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "maxlength": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "parent_repeater": "field_6878a1c2f4b09"
+                }
+            ],
+            "rows_per_page": 20
+        },
+        {
             "key": "field_5ffd9521888e4",
             "label": "Programmatie",
             "name": "fm_show_programmatie",
@@ -161,5 +205,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1683287750
+    "modified": 1784211330
 }

--- a/templates/blocks/blok_dossiers_carrousel.twig
+++ b/templates/blocks/blok_dossiers_carrousel.twig
@@ -12,6 +12,10 @@
         overflow: scroll;
         -webkit-overflow-scrolling: touch;
         scroll-behavior: smooth;
+        scroll-snap-type: x proximity;
+        /* De insets tellen niet mee als zichtbare breedte; partial/scroller.twig
+           gebruikt dit ook als paginagrootte voor de prev/next-knoppen */
+        scroll-padding: 0 var(--grid-inset);
     }
 
     /** sm and up */
@@ -37,6 +41,7 @@
         width: calc((var(--grid-container) - var(--grid-gutter) * (var(--grid-columns) - 1)) / var(--grid-columns));
         min-width: 140px;
         margin: 0 calc(var(--grid-gutter) / 2);
+        scroll-snap-align: start;
     }
 </style>
 
@@ -66,8 +71,8 @@
     <div class="max-w-960 mx-auto px-4">
         <h2 class="font-bold text-3xl pb-4 dark:text-white">Dossiers</h2>
     </div>
-    <div class="slider">
-        <div class="slider-wrapper">
+    <div class="slider" data-scroller>
+        <div class="slider-wrapper" data-scroller-track>
             <div class="slider-container">
                 <div class="slider-padding"></div>
                 {% for term in block.terms %}
@@ -76,14 +81,14 @@
                 <div class="slider-padding"></div>
             </div>
         </div>
-        <div class="shim shim-next js-next bg-white/50 dark:bg-gray-800/50 dark:hover:bg-gray-800/70 hover:bg-white/70"></div>
-        <div class="shim shim-prev js-prev bg-white/50 dark:bg-gray-800/50 dark:hover:bg-gray-800/70 hover:bg-white/70"></div>
-        <button class="slider-btn slider-btn-prev flickity-prev-next-button js-prev text-gray-800"
-                aria-label="Vorige">
+        <div class="shim shim-next bg-white/50 dark:bg-gray-800/50 dark:hover:bg-gray-800/70 hover:bg-white/70" data-scroller-next></div>
+        <div class="shim shim-prev bg-white/50 dark:bg-gray-800/50 dark:hover:bg-gray-800/70 hover:bg-white/70" data-scroller-prev></div>
+        <button class="slider-btn slider-btn-prev flickity-prev-next-button text-gray-800"
+                aria-label="Vorige" data-scroller-prev>
             {{ icon('icon-arrow_back') }}
         </button>
-        <button class="slider-btn slider-btn-next flickity-prev-next-button js-next text-gray-800"
-                aria-label="Volgende">
+        <button class="slider-btn slider-btn-next flickity-prev-next-button text-gray-800"
+                aria-label="Volgende" data-scroller-next>
             {{ icon('icon-arrow_forward') }}
         </button>
     </div>
@@ -111,6 +116,10 @@
         transition: transform 250ms ease-in-out 0s;
         align-items: center;
         justify-content: center;
+    }
+
+    .slider-btn:disabled {
+        display: none;
     }
 
     .slider-btn-prev {
@@ -161,25 +170,4 @@
     }
 </style>
 
-<script>
-    (function ($) {
-        let slider = $('.slider');
-        var position = 0;
-
-        slider.on('click', '.js-next', function (e) {
-            let wrapper = slider.find('.slider-wrapper')[0];
-            let columnCount = getComputedStyle(wrapper, null).getPropertyValue('--grid-columns');
-            position += slider.find('.slider-term').first().outerWidth(true) * columnCount;
-            let maxPosition = slider.find('.slider-container').outerWidth(true) - slider.find('.slider-wrapper').innerWidth();
-            position = Math.min(position, maxPosition);
-            wrapper.scrollLeft = position;
-        });
-        slider.on('click', '.js-prev', function (e) {
-            let wrapper = slider.find('.slider-wrapper')[0];
-            let columnCount = getComputedStyle(wrapper, null).getPropertyValue('--grid-columns');
-            position -= slider.find('.slider-term').first().outerWidth(true) * columnCount;
-            position = Math.max(position, 0);
-            wrapper.scrollLeft = position;
-        });
-    })(jQuery);
-</script>
+{{ include('partial/scroller.twig') }}

--- a/templates/partial/scroller.twig
+++ b/templates/partial/scroller.twig
@@ -1,0 +1,71 @@
+{# Gedeelde prev/next-logica voor horizontale scrollers. Include dit naast elke
+   scroller; het script initialiseert zichzelf één keer per pagina en bindt dan
+   iedere [data-scroller]. Verwachte structuur binnen [data-scroller]:
+   - [data-scroller-track]: het horizontaal scrollende element (verplicht)
+   - [data-scroller-prev] / [data-scroller-next]: klikdoelen, mogen er meerdere zijn;
+     buttons krijgen automatisch hun disabled-status
+   - [data-scroller-nav]: optionele wrapper die verborgen wordt als er niets te scrollen valt
+   De paginagrootte is de trackbreedte minus de scroll-padding, dus zet
+   scroll-padding op de track als de inhoud inspringt. #}
+<script>
+    (function () {
+        if (window.zwScroller) {
+            return;
+        }
+        window.zwScroller = true;
+
+        function initScroller(scroller) {
+            var track = scroller.querySelector('[data-scroller-track]');
+            var nav = scroller.querySelector('[data-scroller-nav]');
+            var prevs = scroller.querySelectorAll('[data-scroller-prev]');
+            var nexts = scroller.querySelectorAll('[data-scroller-next]');
+            if (!track) {
+                return;
+            }
+
+            var tolerance = 4;
+
+            function page() {
+                var style = getComputedStyle(track);
+                return track.clientWidth - (parseFloat(style.scrollPaddingLeft) || 0) - (parseFloat(style.scrollPaddingRight) || 0);
+            }
+
+            function update() {
+                var max = track.scrollWidth - track.clientWidth;
+                if (nav) {
+                    nav.hidden = max <= tolerance;
+                }
+                prevs.forEach(function (el) {
+                    el.disabled = track.scrollLeft <= tolerance;
+                });
+                nexts.forEach(function (el) {
+                    el.disabled = track.scrollLeft >= max - tolerance;
+                });
+            }
+
+            prevs.forEach(function (el) {
+                el.addEventListener('click', function () {
+                    track.scrollBy({left: -page(), behavior: 'smooth'});
+                });
+            });
+            nexts.forEach(function (el) {
+                el.addEventListener('click', function () {
+                    track.scrollBy({left: page(), behavior: 'smooth'});
+                });
+            });
+            track.addEventListener('scroll', update, {passive: true});
+            window.addEventListener('resize', update);
+            update();
+        }
+
+        function init() {
+            document.querySelectorAll('[data-scroller]').forEach(initScroller);
+        }
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+        } else {
+            init();
+        }
+    })();
+</script>

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -163,8 +163,8 @@
         {# Uitzending gemist #}
         {% if gemist.days is not empty %}
             <section id="gemist" class="bg-gray-800 text-white dark:border-t dark:border-gray-700/50">
-                <div class="mx-auto w-full max-w-960 px-4 py-6">
-                    <div class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1">
+                <div class="mx-auto w-full max-w-960 px-4 py-8">
+                    <div class="mb-5 flex flex-wrap items-center gap-x-4 gap-y-1">
                         <h2 class="text-3xl font-bold">Uitzending gemist</h2>
                         <div class="ml-auto flex items-center gap-1.5" data-gemist-nav hidden>
                             <button type="button" data-gemist-newer disabled aria-label="Nieuwere uitzendingen"
@@ -174,15 +174,15 @@
                         </div>
                     </div>
 
-                    <ul class="-mx-4 flex snap-x snap-proximity gap-2 overflow-x-auto px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                    <ul class="-mx-4 flex snap-x snap-proximity gap-4 overflow-x-auto px-4 py-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
                         data-gemist-track style="scroll-padding-left: 1rem">
                         {% for day in gemist.days %}
-                            <li class="w-40 flex-none snap-start rounded-sm bg-gray-700/50 p-3">
+                            <li class="w-44 flex-none snap-start rounded-sm bg-gray-700/50 p-4 text-center">
                                 <span class="block font-round text-xs font-bold tracking-wide text-gray-400 uppercase">{{ day.date.locale('nl').isoFormat('dddd') }}</span>
-                                <span class="mb-2.5 block text-sm font-semibold">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
-                                <div class="flex flex-col gap-1.5">
+                                <span class="mb-3.5 block text-sm font-semibold">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
+                                <div class="flex flex-col gap-2">
                                     {% for time in day.times %}
-                                        <a class="rounded-sm bg-gray-700 px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-gray-600"
+                                        <a class="rounded-sm bg-gray-700 px-3 py-2 text-center text-xs font-bold text-white transition hover:bg-gray-600"
                                            href="{{ options.radio_gemist_baseurl|replace({'<date>': time.format(options.radio_gemist_file)}) }}"
                                            target="_blank" rel="noopener">{{ time.locale('nl').isoFormat('HH:mm') }}</a>
                                     {% endfor %}
@@ -192,7 +192,7 @@
                     </ul>
 
                     {% if gemist.retention_label %}
-                        <p class="mt-2.5 text-sm text-gray-400">Je kunt uitzendingen tot {{ gemist.retention_label }} terugluisteren.</p>
+                        <p class="mt-4 text-sm text-gray-400">Je kunt uitzendingen tot {{ gemist.retention_label }} terugluisteren.</p>
                     {% endif %}
 
                     <script>

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -166,28 +166,23 @@
                 <div class="mx-auto w-full max-w-960 px-4 py-6">
                     <div class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1">
                         <h2 class="text-3xl font-bold">Uitzending gemist</h2>
-                        {% if gemist.days|length > 5 %}
-                            <div class="ml-auto flex items-center gap-1.5">
-                                <button type="button" data-gemist-newer disabled aria-label="Nieuwere uitzendingen"
-                                        class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">‹</button>
-                                <button type="button" data-gemist-older aria-label="Oudere uitzendingen"
-                                        class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">›</button>
-                            </div>
-                        {% endif %}
+                        <div class="ml-auto flex items-center gap-1.5" data-gemist-nav hidden>
+                            <button type="button" data-gemist-newer disabled aria-label="Nieuwere uitzendingen"
+                                    class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">‹</button>
+                            <button type="button" data-gemist-older aria-label="Oudere uitzendingen"
+                                    class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">›</button>
+                        </div>
                     </div>
 
-                    <ul class="flex flex-col gap-2 sm:grid sm:grid-cols-3 md:grid-cols-5">
+                    <ul class="-mx-4 flex snap-x snap-proximity gap-2 overflow-x-auto px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                        data-gemist-track style="scroll-padding-left: 1rem">
                         {% for day in gemist.days %}
-                            <li class="flex items-center gap-3 rounded-sm bg-gray-700/50 p-3 sm:block"
-                                data-gemist-day{% if loop.index0 >= 5 %} style="display: none"{% endif %}>
-                                <div class="flex-1 sm:mb-2.5 sm:flex-none">
-                                    <span class="text-sm font-semibold sm:hidden">{{ day.date.locale('nl').isoFormat('dddd D MMMM') }}</span>
-                                    <span class="hidden font-round text-xs font-bold tracking-wide text-gray-400 uppercase sm:block">{{ day.date.locale('nl').isoFormat('dddd') }}</span>
-                                    <span class="hidden text-sm font-semibold sm:block">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
-                                </div>
-                                <div class="flex gap-1.5 sm:flex-col">
+                            <li class="w-40 flex-none snap-start rounded-sm bg-gray-700/50 p-3">
+                                <span class="block font-round text-xs font-bold tracking-wide text-gray-400 uppercase">{{ day.date.locale('nl').isoFormat('dddd') }}</span>
+                                <span class="mb-2.5 block text-sm font-semibold">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
+                                <div class="flex flex-col gap-1.5">
                                     {% for time in day.times %}
-                                        <a class="rounded-sm bg-gray-700 px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-gray-600 sm:px-0"
+                                        <a class="rounded-sm bg-gray-700 px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-gray-600"
                                            href="{{ options.radio_gemist_baseurl|replace({'<date>': time.format(options.radio_gemist_file)}) }}"
                                            target="_blank" rel="noopener">{{ time.locale('nl').isoFormat('HH:mm') }}</a>
                                     {% endfor %}
@@ -203,38 +198,32 @@
                     <script>
                         (function () {
                             var section = document.getElementById('gemist');
+                            var track = section.querySelector('[data-gemist-track]');
+                            var nav = section.querySelector('[data-gemist-nav]');
                             var newer = section.querySelector('[data-gemist-newer]');
                             var older = section.querySelector('[data-gemist-older]');
-                            if (!newer || !older) {
+                            if (!track || !nav || !newer || !older) {
                                 return;
                             }
 
-                            var days = section.querySelectorAll('[data-gemist-day]');
-                            var pageSize = 5;
-                            var pages = Math.ceil(days.length / pageSize);
-                            var page = 0;
-
-                            function render() {
-                                days.forEach(function (day, i) {
-                                    var visible = i >= page * pageSize && i < (page + 1) * pageSize;
-                                    day.style.display = visible ? '' : 'none';
-                                });
-                                newer.disabled = page === 0;
-                                older.disabled = page + 1 >= pages;
+                            function update() {
+                                var max = track.scrollWidth - track.clientWidth;
+                                var last = track.lastElementChild;
+                                nav.hidden = max <= 4;
+                                newer.disabled = track.scrollLeft <= 4;
+                                older.disabled = !last
+                                    || last.getBoundingClientRect().right <= track.getBoundingClientRect().right + 4;
                             }
 
                             newer.addEventListener('click', function () {
-                                if (page > 0) {
-                                    page--;
-                                    render();
-                                }
+                                track.scrollBy({left: -track.clientWidth, behavior: 'smooth'});
                             });
                             older.addEventListener('click', function () {
-                                if (page + 1 < pages) {
-                                    page++;
-                                    render();
-                                }
+                                track.scrollBy({left: track.clientWidth, behavior: 'smooth'});
                             });
+                            track.addEventListener('scroll', update, {passive: true});
+                            window.addEventListener('resize', update);
+                            update();
                         })();
                     </script>
                 </div>

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -162,20 +162,20 @@
 
         {# Uitzending gemist #}
         {% if gemist.days is not empty %}
-            <section id="gemist" class="bg-gray-800 text-white dark:border-t dark:border-gray-700/50">
+            <section data-scroller class="bg-gray-800 text-white dark:border-t dark:border-gray-700/50">
                 <div class="mx-auto w-full max-w-960 px-4 py-8">
                     <div class="mb-5 flex flex-wrap items-center gap-x-4 gap-y-1">
                         <h2 class="text-3xl font-bold">Uitzending gemist</h2>
-                        <div class="ml-auto flex items-center gap-1.5" data-gemist-nav hidden>
-                            <button type="button" data-gemist-newer disabled aria-label="Nieuwere uitzendingen"
+                        <div class="ml-auto flex items-center gap-1.5" data-scroller-nav hidden>
+                            <button type="button" data-scroller-prev disabled aria-label="Nieuwere uitzendingen"
                                     class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">{{ icon('icon-arrow_back') }}</button>
-                            <button type="button" data-gemist-older aria-label="Oudere uitzendingen"
+                            <button type="button" data-scroller-next aria-label="Oudere uitzendingen"
                                     class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">{{ icon('icon-arrow_forward') }}</button>
                         </div>
                     </div>
 
                     <ul class="-mx-4 flex snap-x snap-proximity gap-3 overflow-x-auto px-4 py-1 sm:gap-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-                        data-gemist-track style="scroll-padding-left: 1rem">
+                        data-scroller-track style="scroll-padding-left: 1rem">
                         {% for day in gemist.days %}
                             <li class="w-28 flex-none snap-start rounded-sm bg-gray-700/50 p-3 text-center sm:w-44 sm:p-4">
                                 <span class="block font-round text-xs font-bold tracking-wide text-gray-400 uppercase">
@@ -198,36 +198,7 @@
                         <p class="mt-4 text-sm text-gray-400">Je kunt uitzendingen tot {{ gemist.retention_label }} terugluisteren.</p>
                     {% endif %}
 
-                    <script>
-                        (function () {
-                            var section = document.getElementById('gemist');
-                            var track = section.querySelector('[data-gemist-track]');
-                            var nav = section.querySelector('[data-gemist-nav]');
-                            var newer = section.querySelector('[data-gemist-newer]');
-                            var older = section.querySelector('[data-gemist-older]');
-                            if (!track || !nav || !newer || !older) {
-                                return;
-                            }
-
-                            function update() {
-                                var tolerance = 4;
-                                var max = track.scrollWidth - track.clientWidth;
-                                nav.hidden = max <= tolerance;
-                                newer.disabled = track.scrollLeft <= tolerance;
-                                older.disabled = track.scrollLeft >= max - tolerance;
-                            }
-
-                            newer.addEventListener('click', function () {
-                                track.scrollBy({left: -track.clientWidth, behavior: 'smooth'});
-                            });
-                            older.addEventListener('click', function () {
-                                track.scrollBy({left: track.clientWidth, behavior: 'smooth'});
-                            });
-                            track.addEventListener('scroll', update, {passive: true});
-                            window.addEventListener('resize', update);
-                            update();
-                        })();
-                    </script>
+                    {{ include('partial/scroller.twig') }}
                 </div>
             </section>
         {% endif %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -9,10 +9,12 @@
         <header class="relative overflow-hidden bg-roze bg-gradient-to-r from-[#8f004e] via-[#c7006d] to-roze">
             <div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
                 {# Kleine driehoeken uit het ZuidWest FM-beeldmerk, alle kanten op #}
-                <svg class="absolute inset-0 h-full w-full" viewBox="0 0 1200 300" preserveAspectRatio="xMidYMid slice">
+                <svg class="absolute h-0 w-0" focusable="false">
                     <defs>
                         <path id="zwfm-driehoek" d="M28 -98 L28 98 L-56 0 Z" stroke-width="20" stroke-linejoin="round"/>
                     </defs>
+                </svg>
+                <svg class="absolute inset-0 h-full w-full max-md:hidden" viewBox="0 0 1200 300" preserveAspectRatio="xMidYMid slice">
                     {% set driehoeken = [
                         [80, 255, 15, 0.22, '#ffffff', 0.08],
                         [170, 120, 250, 0.12, '#ff9dce', 0.12],
@@ -32,6 +34,26 @@
                         [1170, 80, 60, 0.24, '#ff9dce', 0.28],
                     ] %}
                     {% for d in driehoeken %}
+                        <use href="#zwfm-driehoek" fill="{{ d[4] }}" stroke="{{ d[4] }}" opacity="{{ d[5] }}"
+                             transform="translate({{ d[0] }} {{ d[1] }}) rotate({{ d[2] }}) scale({{ d[3] }})"/>
+                    {% endfor %}
+                </svg>
+                {# Mobiel is de header smal en hoog; eigen compositie zodat de driehoeken niet wegvallen door de slice-crop #}
+                <svg class="absolute inset-0 h-full w-full md:hidden" viewBox="0 0 390 220" preserveAspectRatio="xMidYMid slice">
+                    {% set driehoeken_mobiel = [
+                        [30, 110, 330, 0.14, '#8f004e', 0.22],
+                        [48, 198, 20, 0.18, '#ffffff', 0.14],
+                        [95, 52, 140, 0.15, '#ff9dce', 0.22],
+                        [150, 205, 250, 0.17, '#8f004e', 0.26],
+                        [205, 26, 75, 0.16, '#ffffff', 0.14],
+                        [240, 128, 310, 0.2, '#ff9dce', 0.24],
+                        [260, 195, 100, 0.13, '#ffffff', 0.12],
+                        [295, 205, 160, 0.2, '#8f004e', 0.28],
+                        [315, 55, 225, 0.22, '#ffffff', 0.16],
+                        [360, 145, 30, 0.24, '#ff9dce', 0.3],
+                        [374, 18, 190, 0.16, '#8f004e', 0.26],
+                    ] %}
+                    {% for d in driehoeken_mobiel %}
                         <use href="#zwfm-driehoek" fill="{{ d[4] }}" stroke="{{ d[4] }}" opacity="{{ d[5] }}"
                              transform="translate({{ d[0] }} {{ d[1] }}) rotate({{ d[2] }}) scale({{ d[3] }})"/>
                     {% endfor %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -113,8 +113,10 @@
                         <div class="flex flex-col gap-3.5">
                             {% for maker in presentatoren %}
                                 <div class="flex gap-3">
-                                    <img src="{{ maker.avatar({size: 104}) }}" alt="{{ maker.name }}" width="52" height="52"
-                                         loading="lazy" class="h-13 w-13 flex-none rounded-full object-cover">
+                                    <img src="{{ maker.avatar|imgproxy(52, 52) }}"
+                                         srcset="{{ maker.avatar|imgproxy(52 * 2, 52 * 2) }} 2x"
+                                         alt="{{ maker.name }}" width="52" height="52"
+                                         loading="lazy" class="h-13 w-13 flex-none rounded-sm object-cover">
                                     <div>
                                         <p class="text-sm font-bold text-gray-900 dark:text-white">{{ maker.name }}</p>
                                         {% if maker.meta('description') %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -87,8 +87,8 @@
             </div>
         </header>
 
-        <div class="mx-auto max-w-960 px-4 pt-7 lg:grid lg:grid-cols-[1fr_20rem] lg:gap-x-11 lg:gap-y-8 lg:pt-9">
-            <div class="lg:col-start-1 lg:row-start-1">
+        <div class="mx-auto max-w-960 px-4 py-7 lg:grid lg:grid-cols-[1fr_20rem] lg:gap-x-11 lg:py-9">
+            <div>
                 {# Omschrijving #}
                 <div class="prose prose-lg dark:prose-invert mb-5">
                     {{ post.content }}
@@ -106,7 +106,7 @@
             </div>
 
             {# Zijbalk #}
-            <aside class="mt-6 flex flex-col gap-4 lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:mt-0">
+            <aside class="mt-6 flex flex-col gap-4 lg:mt-0">
                 {% if presentatoren is not empty %}
                     <div class="rounded-sm border border-gray-800/10 bg-gray-50 p-4 dark:border-gray-200/10 dark:bg-gray-700/40">
                         <h2 class="mb-3.5 font-round text-sm font-bold tracking-wide text-gray-400 uppercase">De makers</h2>
@@ -156,10 +156,12 @@
                 {% endif %}
 
             </aside>
+        </div>
 
-            {# Uitzending gemist #}
-            {% if gemist.days is not empty %}
-                <section id="gemist" class="-mx-4 mt-6 bg-gray-800 p-4 text-white sm:mx-0 sm:rounded-sm lg:col-start-1 lg:row-start-2 lg:mt-0 dark:border dark:border-gray-700/50">
+        {# Uitzending gemist #}
+        {% if gemist.days is not empty %}
+            <section id="gemist" class="bg-gray-800 text-white dark:border-t dark:border-gray-700/50">
+                <div class="mx-auto w-full max-w-960 px-4 py-6">
                     <div class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1">
                         <h2 class="text-3xl font-bold">Uitzending gemist</h2>
                         {% if gemist.days|length > 5 %}
@@ -233,10 +235,8 @@
                             });
                         })();
                     </script>
-                </section>
-            {% endif %}
-        </div>
-
-        <div class="pb-8"></div>
+                </div>
+            </section>
+        {% endif %}
     </article>
 {% endblock %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -195,7 +195,7 @@
                     </ul>
 
                     {% if gemist.retention_label %}
-                        <p class="mt-2.5 text-sm text-gray-400">Uitzendingen blijven {{ gemist.retention_label }} terug te luisteren.</p>
+                        <p class="mt-2.5 text-sm text-gray-400">Je kunt uitzendingen tot {{ gemist.retention_label }} terugluisteren.</p>
                     {% endif %}
 
                     <script>

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -7,13 +7,20 @@
     <article id="post-{{ post.id }}" class="{{ post.class }}">
         {# Hero #}
         <header class="relative overflow-hidden bg-roze">
-            {% if post.thumbnail %}
-                <div class="absolute -right-10 -top-2 h-36 w-36 rotate-45 overflow-hidden rounded-sm opacity-85 md:top-1/2 md:right-24 md:h-72 md:w-72 md:-translate-y-1/2"
-                     aria-hidden="true">
-                    <img src="{{ post.thumbnail.src|imgproxy(600, 600) }}" alt=""
-                         class="absolute top-1/2 left-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 -rotate-45 scale-150 object-cover opacity-45 mix-blend-luminosity">
-                </div>
-            {% endif %}
+            <div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+                {# Uitzendgolven #}
+                <svg class="absolute top-1/2 -right-24 h-72 w-72 -translate-y-1/2 text-white md:-right-8 md:h-[26rem] md:w-[26rem]"
+                     viewBox="0 0 400 400" fill="none">
+                    <circle cx="200" cy="200" r="8" fill="currentColor" fill-opacity=".35"/>
+                    <circle cx="200" cy="200" r="60" stroke="currentColor" stroke-opacity=".3" stroke-width="2"/>
+                    <circle cx="200" cy="200" r="110" stroke="currentColor" stroke-opacity=".2" stroke-width="2"/>
+                    <circle cx="200" cy="200" r="160" stroke="currentColor" stroke-opacity=".12" stroke-width="2"/>
+                    <circle cx="200" cy="200" r="199" stroke="currentColor" stroke-opacity=".07" stroke-width="2"/>
+                </svg>
+                {# Ruiten als extra lagen #}
+                <div class="absolute -right-10 -bottom-16 h-40 w-40 rotate-45 bg-white/10"></div>
+                <div class="absolute -top-10 right-40 h-24 w-24 rotate-45 bg-black/10 max-md:hidden"></div>
+            </div>
 
             <div class="relative mx-auto max-w-960 px-4 pt-6 pb-8 md:pt-7 md:pb-9">
                 <nav class="mb-5 text-xs font-semibold text-white/70 md:text-sm" aria-label="Kruimelpad">
@@ -174,7 +181,14 @@
                             {% endfor %}
                         {% endif %}
                         {% if following_show %}
-                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Aansluitend: {{ following_show.name }}</p>
+                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                Aansluitend:
+                                {% if following_show.show %}
+                                    <a class="underline transition hover:text-roze" href="{{ following_show.show.link }}">{{ following_show.name }}</a>
+                                {% else %}
+                                    {{ following_show.name }}
+                                {% endif %}
+                            </p>
                         {% endif %}
                     </div>
                 {% endif %}
@@ -183,28 +197,6 @@
         </div>
 
         {# Meer programma's #}
-        <div class="mx-auto max-w-960 px-4">
-            <div class="mt-7 border-t border-gray-200 py-4 pb-8 dark:border-gray-700">
-                <p class="font-round text-sm font-bold tracking-wide text-gray-400 uppercase">Meer FM-programma's</p>
-                <ul class="mt-2 flex flex-wrap items-center gap-2">
-                    {% for show in other_shows|slice(0, 4) %}
-                        <li>
-                            <a class="block rounded-sm bg-gray-100 px-2 py-1 text-sm text-gray-900 transition hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
-                               href="{{ show.link }}">{{ show.title }}</a>
-                        </li>
-                    {% endfor %}
-                    {% if other_shows is not empty %}
-                        <li class="mx-1 h-5 border-l border-gray-300 dark:border-gray-500" aria-hidden="true" role="presentation"></li>
-                    {% endif %}
-                    <li>
-                        <a class="inline-flex items-center gap-1 rounded-sm bg-roze py-1 pr-1.5 pl-2 text-sm text-white transition hover:bg-roze/80"
-                           href="{{ function('get_post_type_archive_link', 'fm') }}">
-                            <span>Alle programma's</span>
-                            <span class="size-4 shrink-0 [&>svg]:size-full" aria-hidden="true">{{ icon('icon-chevron_right') }}</span>
-                        </a>
-                    </li>
-                </ul>
-            </div>
-        </div>
+        <div class="pb-8"></div>
     </article>
 {% endblock %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -72,7 +72,7 @@
                 </nav>
 
                 {% if programmatie is not empty %}
-                    <p class="mb-2 font-round text-sm font-extrabold tracking-wide text-white/90">
+                    <p class="mb-2 font-round text-sm font-extrabold tracking-wide text-white/90 uppercase">
                         {% for entry in programmatie %}
                             {{- entry|format_schedule_compact }}{{ not loop.last ? ' · ' -}}
                         {% endfor %}
@@ -139,7 +139,7 @@
                             <p class="text-xl font-black text-gray-900 dark:text-white">{{ programmatie[0].fm_show_starttijd|slice(0, 5) }} – {{ programmatie[0].fm_show_eindtijd|slice(0, 5) }}</p>
                         {% else %}
                             {% for entry in programmatie %}
-                                <p class="text-sm font-bold text-gray-900 dark:text-white">{{ entry|format_schedule_compact }}</p>
+                                <p class="text-sm font-bold text-gray-900 uppercase dark:text-white">{{ entry|format_schedule_compact }}</p>
                             {% endfor %}
                         {% endif %}
                         {% if following_show %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -8,7 +8,10 @@
         {# Hero #}
         <header class="relative overflow-hidden bg-roze bg-gradient-to-r from-[#8f004e] via-[#c7006d] to-roze">
             <div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-                {# Kleine driehoeken uit het ZuidWest FM-beeldmerk, alle kanten op #}
+                {# Kleine driehoeken uit het ZuidWest FM-beeldmerk, alle kanten op.
+                   Ze mogen elkaar nooit overlappen: elke driehoek past ongeacht rotatie binnen een
+                   cirkel met straal 112 x schaal rond zijn ankerpunt, dus houd de afstand tussen twee
+                   ankers altijd groter dan 112 x (schaal a + schaal b). #}
                 <svg class="absolute h-0 w-0" focusable="false">
                     <defs>
                         <path id="zwfm-driehoek" d="M28 -98 L28 98 L-56 0 Z" stroke-width="20" stroke-linejoin="round"/>
@@ -47,7 +50,7 @@
                         [150, 205, 250, 0.17, '#8f004e', 0.26],
                         [205, 26, 75, 0.16, '#ffffff', 0.14],
                         [240, 128, 310, 0.2, '#ff9dce', 0.24],
-                        [260, 195, 100, 0.13, '#ffffff', 0.12],
+                        [255, 178, 100, 0.13, '#ffffff', 0.12],
                         [295, 205, 160, 0.2, '#8f004e', 0.28],
                         [315, 55, 225, 0.22, '#ffffff', 0.16],
                         [360, 145, 30, 0.24, '#ff9dce', 0.3],

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -174,11 +174,14 @@
                         </div>
                     </div>
 
-                    <ul class="-mx-4 flex snap-x snap-proximity gap-4 overflow-x-auto px-4 py-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                    <ul class="-mx-4 flex snap-x snap-proximity gap-3 overflow-x-auto px-4 py-1 sm:gap-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
                         data-gemist-track style="scroll-padding-left: 1rem">
                         {% for day in gemist.days %}
-                            <li class="w-44 flex-none snap-start rounded-sm bg-gray-700/50 p-4 text-center">
-                                <span class="block font-round text-xs font-bold tracking-wide text-gray-400 uppercase">{{ day.date.locale('nl').isoFormat('dddd') }}</span>
+                            <li class="w-28 flex-none snap-start rounded-sm bg-gray-700/50 p-3 text-center sm:w-44 sm:p-4">
+                                <span class="block font-round text-xs font-bold tracking-wide text-gray-400 uppercase">
+                                    <span class="sm:hidden">{{ day.date.locale('nl').isoFormat('dd') }}</span>
+                                    <span class="hidden sm:inline">{{ day.date.locale('nl').isoFormat('dddd') }}</span>
+                                </span>
                                 <span class="mb-3.5 block text-sm font-semibold">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
                                 <div class="flex flex-col gap-2">
                                     {% for time in day.times %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -60,39 +60,38 @@
 
                 {# Uitzending gemist #}
                 {% if gemist.days is not empty %}
-                    <section id="gemist" class="mb-8 scroll-mt-32">
-                        <div class="mb-3.5 flex flex-wrap items-baseline gap-x-4 gap-y-1">
-                            <h2 class="text-2xl font-bold text-black dark:text-white">Uitzending gemist</h2>
-                            <div class="ml-auto flex items-center gap-2.5 text-sm font-bold">
-                                {% if gemist.week > 0 %}
-                                    <a class="text-roze hover:underline" href="?week={{ gemist.week - 1 }}#gemist">‹ nieuwer</a>
-                                {% endif %}
-                                <span class="text-gray-900 dark:text-white">
-                                    {%- if gemist.week == 0 -%}
-                                        deze week
-                                    {%- elseif gemist.week == 1 -%}
-                                        vorige week
-                                    {%- else -%}
-                                        {{ gemist.week }} weken terug
-                                    {%- endif -%}
-                                </span>
-                                {% if gemist.week + 1 < gemist.weeks %}
-                                    <a class="text-roze hover:underline" href="?week={{ gemist.week + 1 }}#gemist">{{ gemist.week == 0 ? 'vorige week' : 'ouder' }} ›</a>
-                                {% endif %}
-                            </div>
+                    <section id="gemist" class="mb-8 scroll-mt-32 rounded-lg bg-gray-800 p-4 text-white sm:p-5 dark:border dark:border-gray-600 dark:bg-gray-900">
+                        <div class="mb-3.5 flex flex-wrap items-center gap-x-4 gap-y-1">
+                            <h2 class="text-2xl font-bold">Uitzending gemist</h2>
+                            {% if gemist.pages > 1 %}
+                                <div class="ml-auto flex items-center gap-1.5">
+                                    {% if gemist.page > 0 %}
+                                        <a class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700/50 font-bold transition hover:bg-roze"
+                                           href="?gemist={{ gemist.page - 1 }}#gemist" aria-label="Nieuwere uitzendingen">‹</a>
+                                    {% else %}
+                                        <span class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700/30 font-bold text-gray-500" aria-hidden="true">‹</span>
+                                    {% endif %}
+                                    {% if gemist.page + 1 < gemist.pages %}
+                                        <a class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700/50 font-bold transition hover:bg-roze"
+                                           href="?gemist={{ gemist.page + 1 }}#gemist" aria-label="Oudere uitzendingen">›</a>
+                                    {% else %}
+                                        <span class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700/30 font-bold text-gray-500" aria-hidden="true">›</span>
+                                    {% endif %}
+                                </div>
+                            {% endif %}
                         </div>
 
-                        <ul class="sm:grid sm:grid-cols-3 sm:gap-2.5 md:grid-cols-5">
+                        <ul class="flex flex-col gap-2.5 sm:grid sm:grid-cols-3 md:grid-cols-5">
                             {% for day in gemist.days %}
-                                <li class="flex items-center gap-3 border-t border-gray-200 py-3 sm:block sm:rounded-lg sm:border sm:p-3 dark:border-gray-600">
+                                <li class="flex items-center gap-3 rounded-sm bg-gray-700/50 p-3 sm:block">
                                     <div class="flex-1 sm:mb-2.5 sm:flex-none">
-                                        <span class="text-sm font-bold text-gray-900 sm:hidden dark:text-white">{{ day.date.locale('nl').isoFormat('dddd D MMMM') }}</span>
+                                        <span class="text-sm font-semibold sm:hidden">{{ day.date.locale('nl').isoFormat('dddd D MMMM') }}</span>
                                         <span class="hidden text-xs font-bold tracking-wide text-gray-400 uppercase sm:block">{{ day.date.locale('nl').isoFormat('dd') }}</span>
-                                        <span class="hidden text-sm font-bold text-gray-900 sm:block dark:text-white">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
+                                        <span class="hidden text-sm font-semibold sm:block">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
                                     </div>
                                     <div class="flex gap-1.5 sm:flex-col">
                                         {% for time in day.times %}
-                                            <a class="rounded-full border-[1.5px] border-roze px-3 py-1.5 text-center text-xs font-bold text-roze transition hover:bg-roze hover:text-white sm:rounded-md sm:px-0"
+                                            <a class="rounded-sm bg-roze px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-[#b00061] sm:px-0"
                                                href="{{ options.radio_gemist_baseurl|replace({'<date>': time.format(options.radio_gemist_file)}) }}"
                                                target="_blank" rel="noopener">▸ {{ time.locale('nl').isoFormat('HH:mm') }}</a>
                                         {% endfor %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -6,9 +6,9 @@
 
     <article id="post-{{ post.id }}" class="{{ post.class }}">
         {# Hero #}
-        <header class="relative overflow-hidden bg-gradient-to-r from-[#8f004e] via-[#c7006d] to-roze">
+        <header class="relative overflow-hidden bg-roze">
             {% if post.thumbnail %}
-                <div class="absolute -right-10 -top-2 h-36 w-36 rotate-45 overflow-hidden rounded-2xl opacity-85 md:top-1/2 md:right-24 md:h-72 md:w-72 md:-translate-y-1/2 md:rounded-3xl"
+                <div class="absolute -right-10 -top-2 h-36 w-36 rotate-45 overflow-hidden rounded-sm opacity-85 md:top-1/2 md:right-24 md:h-72 md:w-72 md:-translate-y-1/2"
                      aria-hidden="true">
                     <img src="{{ post.thumbnail.src|imgproxy(600, 600) }}" alt=""
                          class="absolute top-1/2 left-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 -rotate-45 scale-150 object-cover opacity-45 mix-blend-luminosity">
@@ -24,13 +24,11 @@
                 </nav>
 
                 {% if programmatie is not empty %}
-                    <div class="mb-3 flex flex-wrap gap-1.5">
+                    <p class="mb-2 font-round text-sm font-extrabold tracking-wide text-white/90 uppercase">
                         {% for entry in programmatie %}
-                            <span class="inline-flex items-center gap-2 rounded-full bg-white/15 px-3.5 py-1.5 text-xs font-bold text-white md:text-sm">
-                                <span class="h-1.5 w-1.5 rounded-full bg-white"></span>{{ entry|format_schedule_compact }}
-                            </span>
+                            {{- entry|format_schedule_compact }}{{ not loop.last ? ' · ' -}}
                         {% endfor %}
-                    </div>
+                    </p>
                 {% endif %}
 
                 <h1 class="font-round text-4xl leading-none font-black text-white uppercase md:text-5xl">{{ post.title }}</h1>
@@ -53,45 +51,38 @@
                 {% if rubrieken is not empty %}
                     <div class="mb-9 flex flex-wrap gap-2">
                         {% for rubriek in rubrieken %}
-                            <span class="rounded-full bg-pink-100 px-3.5 py-1.5 text-xs font-bold text-[#b00061] dark:bg-roze/20 dark:text-pink-300">{{ rubriek.fm_show_rubriek_naam }}</span>
+                            <span class="rounded-sm bg-gray-100 px-2 py-1 text-sm text-gray-900 dark:bg-gray-700 dark:text-gray-100">{{ rubriek.fm_show_rubriek_naam }}</span>
                         {% endfor %}
                     </div>
                 {% endif %}
 
                 {# Uitzending gemist #}
                 {% if gemist.days is not empty %}
-                    <section id="gemist" class="mb-8 scroll-mt-32 rounded-lg bg-gray-800 p-4 text-white sm:p-5 dark:border dark:border-gray-600 dark:bg-gray-900">
-                        <div class="mb-3.5 flex flex-wrap items-center gap-x-4 gap-y-1">
-                            <h2 class="text-2xl font-bold">Uitzending gemist</h2>
-                            {% if gemist.pages > 1 %}
+                    <section id="gemist" class="mb-8 rounded-sm bg-gray-800 p-4 text-white dark:border dark:border-gray-700/50">
+                        <div class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1">
+                            <h2 class="text-3xl font-bold">Uitzending gemist</h2>
+                            {% if gemist.days|length > 5 %}
                                 <div class="ml-auto flex items-center gap-1.5">
-                                    {% if gemist.page > 0 %}
-                                        <a class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700/50 font-bold transition hover:bg-roze"
-                                           href="?gemist={{ gemist.page - 1 }}#gemist" aria-label="Nieuwere uitzendingen">‹</a>
-                                    {% else %}
-                                        <span class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700/30 font-bold text-gray-500" aria-hidden="true">‹</span>
-                                    {% endif %}
-                                    {% if gemist.page + 1 < gemist.pages %}
-                                        <a class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700/50 font-bold transition hover:bg-roze"
-                                           href="?gemist={{ gemist.page + 1 }}#gemist" aria-label="Oudere uitzendingen">›</a>
-                                    {% else %}
-                                        <span class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700/30 font-bold text-gray-500" aria-hidden="true">›</span>
-                                    {% endif %}
+                                    <button type="button" data-gemist-newer disabled aria-label="Nieuwere uitzendingen"
+                                            class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">‹</button>
+                                    <button type="button" data-gemist-older aria-label="Oudere uitzendingen"
+                                            class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">›</button>
                                 </div>
                             {% endif %}
                         </div>
 
-                        <ul class="flex flex-col gap-2.5 sm:grid sm:grid-cols-3 md:grid-cols-5">
+                        <ul class="flex flex-col gap-2 sm:grid sm:grid-cols-3 md:grid-cols-5">
                             {% for day in gemist.days %}
-                                <li class="flex items-center gap-3 rounded-sm bg-gray-700/50 p-3 sm:block">
+                                <li class="flex items-center gap-3 rounded-sm bg-gray-700/50 p-3 sm:block"
+                                    data-gemist-day{% if loop.index0 >= 5 %} style="display: none"{% endif %}>
                                     <div class="flex-1 sm:mb-2.5 sm:flex-none">
                                         <span class="text-sm font-semibold sm:hidden">{{ day.date.locale('nl').isoFormat('dddd D MMMM') }}</span>
-                                        <span class="hidden text-xs font-bold tracking-wide text-gray-400 uppercase sm:block">{{ day.date.locale('nl').isoFormat('dd') }}</span>
+                                        <span class="hidden font-round text-xs font-bold tracking-wide text-gray-400 uppercase sm:block">{{ day.date.locale('nl').isoFormat('dd') }}</span>
                                         <span class="hidden text-sm font-semibold sm:block">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
                                     </div>
                                     <div class="flex gap-1.5 sm:flex-col">
                                         {% for time in day.times %}
-                                            <a class="rounded-sm bg-roze px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-[#b00061] sm:px-0"
+                                            <a class="rounded-sm bg-roze px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-roze/80 sm:px-0"
                                                href="{{ options.radio_gemist_baseurl|replace({'<date>': time.format(options.radio_gemist_file)}) }}"
                                                target="_blank" rel="noopener">▸ {{ time.locale('nl').isoFormat('HH:mm') }}</a>
                                         {% endfor %}
@@ -103,6 +94,44 @@
                         {% if gemist.retention_label %}
                             <p class="mt-2.5 text-sm text-gray-400">Uitzendingen blijven {{ gemist.retention_label }} terug te luisteren.</p>
                         {% endif %}
+
+                        <script>
+                            (function () {
+                                var section = document.getElementById('gemist');
+                                var newer = section.querySelector('[data-gemist-newer]');
+                                var older = section.querySelector('[data-gemist-older]');
+                                if (!newer || !older) {
+                                    return;
+                                }
+
+                                var days = section.querySelectorAll('[data-gemist-day]');
+                                var pageSize = 5;
+                                var pages = Math.ceil(days.length / pageSize);
+                                var page = 0;
+
+                                function render() {
+                                    days.forEach(function (day, i) {
+                                        var visible = i >= page * pageSize && i < (page + 1) * pageSize;
+                                        day.style.display = visible ? '' : 'none';
+                                    });
+                                    newer.disabled = page === 0;
+                                    older.disabled = page + 1 >= pages;
+                                }
+
+                                newer.addEventListener('click', function () {
+                                    if (page > 0) {
+                                        page--;
+                                        render();
+                                    }
+                                });
+                                older.addEventListener('click', function () {
+                                    if (page + 1 < pages) {
+                                        page++;
+                                        render();
+                                    }
+                                });
+                            })();
+                        </script>
                     </section>
                 {% endif %}
             </div>
@@ -110,8 +139,8 @@
             {# Zijbalk #}
             <aside class="mt-4 flex flex-col gap-4 lg:mt-0">
                 {% if presentatoren is not empty %}
-                    <div class="rounded-lg border border-gray-200 bg-gray-50 p-5 dark:border-gray-600 dark:bg-gray-700/40">
-                        <h2 class="mb-3.5 font-round text-xs font-bold tracking-wider text-gray-500 uppercase dark:text-gray-400">De makers</h2>
+                    <div class="rounded-sm border border-gray-800/10 bg-gray-50 p-4 dark:border-gray-200/10 dark:bg-gray-700/40">
+                        <h2 class="mb-3.5 font-round text-sm font-bold tracking-wide text-gray-400 uppercase">De makers</h2>
                         <div class="flex flex-col gap-3.5">
                             {% for maker in presentatoren %}
                                 <div class="flex gap-3">
@@ -130,11 +159,11 @@
                 {% endif %}
 
                 {% if programmatie is not empty %}
-                    <div class="rounded-lg border border-gray-200 bg-gray-50 p-5 dark:border-gray-600 dark:bg-gray-700/40">
-                        <h2 class="mb-3 font-round text-xs font-bold tracking-wider text-gray-500 uppercase dark:text-gray-400">Uitzendschema</h2>
+                    <div class="rounded-sm border border-gray-800/10 bg-gray-50 p-4 dark:border-gray-200/10 dark:bg-gray-700/40">
+                        <h2 class="mb-3 font-round text-sm font-bold tracking-wide text-gray-400 uppercase">Uitzendschema</h2>
                         <div class="mb-2.5 flex gap-1.5">
                             {% for dayname, label in {maandag: 'ma', dinsdag: 'di', woensdag: 'wo', donderdag: 'do', vrijdag: 'vr', zaterdag: 'za', zondag: 'zo'} %}
-                                <span class="flex-1 rounded py-1.5 text-center text-xs font-bold {{ dayname in schedule_days ? 'bg-roze text-white' : 'bg-gray-200 text-gray-400 dark:bg-gray-600 dark:text-gray-400' }}">{{ label }}</span>
+                                <span class="flex-1 rounded-sm py-1.5 text-center text-xs font-bold {{ dayname in schedule_days ? 'bg-roze text-white' : 'bg-gray-200 text-gray-400 dark:bg-gray-600 dark:text-gray-400' }}">{{ label }}</span>
                             {% endfor %}
                         </div>
                         {% if programmatie|length == 1 %}
@@ -154,20 +183,28 @@
         </div>
 
         {# Meer programma's #}
-        {% if other_shows is not empty %}
-            <div class="mx-auto max-w-960 px-4">
-                <div class="mt-7 flex flex-wrap items-center gap-3 border-t border-gray-200 py-4 pb-6 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
-                    <span class="font-bold text-gray-900 dark:text-white">Meer FM-programma's:</span>
+        <div class="mx-auto max-w-960 px-4">
+            <div class="mt-7 border-t border-gray-200 py-4 pb-8 dark:border-gray-700">
+                <p class="font-round text-sm font-bold tracking-wide text-gray-400 uppercase">Meer FM-programma's</p>
+                <ul class="mt-2 flex flex-wrap items-center gap-2">
                     {% for show in other_shows|slice(0, 4) %}
-                        <a class="rounded-full border border-gray-200 px-3 py-1 font-semibold transition hover:border-roze hover:text-roze dark:border-gray-600"
-                           href="{{ show.link }}">{{ show.title }}</a>
+                        <li>
+                            <a class="block rounded-sm bg-gray-100 px-2 py-1 text-sm text-gray-900 transition hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+                               href="{{ show.link }}">{{ show.title }}</a>
+                        </li>
                     {% endfor %}
-                    <a class="font-bold text-roze hover:underline md:ml-auto"
-                       href="{{ function('get_post_type_archive_link', 'fm') }}">Alle programma's →</a>
-                </div>
+                    {% if other_shows is not empty %}
+                        <li class="mx-1 h-5 border-l border-gray-300 dark:border-gray-500" aria-hidden="true" role="presentation"></li>
+                    {% endif %}
+                    <li>
+                        <a class="inline-flex items-center gap-1 rounded-sm bg-roze py-1 pr-1.5 pl-2 text-sm text-white transition hover:bg-roze/80"
+                           href="{{ function('get_post_type_archive_link', 'fm') }}">
+                            <span>Alle programma's</span>
+                            <span class="size-4 shrink-0 [&>svg]:size-full" aria-hidden="true">{{ icon('icon-chevron_right') }}</span>
+                        </a>
+                    </li>
+                </ul>
             </div>
-        {% else %}
-            <div class="pb-8"></div>
-        {% endif %}
+        </div>
     </article>
 {% endblock %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -72,7 +72,7 @@
                 </nav>
 
                 {% if programmatie is not empty %}
-                    <p class="mb-2 font-round text-sm font-extrabold tracking-wide text-white/90 uppercase">
+                    <p class="mb-2 font-round text-sm font-extrabold tracking-wide text-white/90">
                         {% for entry in programmatie %}
                             {{- entry|format_schedule_compact }}{{ not loop.last ? ' · ' -}}
                         {% endfor %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -8,19 +8,33 @@
         {# Hero #}
         <header class="relative overflow-hidden bg-roze bg-gradient-to-r from-[#8f004e] via-[#c7006d] to-roze">
             <div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-                {# Beeldmerk ZuidWest FM: linker- en onderdriehoek met ronde hoeken #}
-                <svg class="absolute top-1/2 -right-10 h-[135%] w-auto -translate-y-1/2 text-white opacity-10"
-                     viewBox="0 0 300 300">
-                    <g id="zwfm-merk" fill="currentColor" stroke="currentColor" stroke-width="10" stroke-linejoin="round">
-                        <path d="M91 7 L91 203 L7 105 Z"/>
-                        <path d="M97 215 L293 215 L195 293 Z"/>
-                    </g>
-                </svg>
-                <svg class="absolute right-64 -bottom-8 h-28 w-28 text-[#8f004e] opacity-40 max-md:hidden" viewBox="0 0 300 300">
-                    <use href="#zwfm-merk"/>
-                </svg>
-                <svg class="absolute -top-6 right-40 h-20 w-20 rotate-180 text-[#ff9dce] opacity-30" viewBox="0 0 300 300">
-                    <use href="#zwfm-merk"/>
+                {# Kleine driehoeken uit het ZuidWest FM-beeldmerk, alle kanten op #}
+                <svg class="absolute inset-0 h-full w-full" viewBox="0 0 1200 300" preserveAspectRatio="xMidYMid slice">
+                    <defs>
+                        <path id="zwfm-driehoek" d="M28 -98 L28 98 L-56 0 Z" stroke-width="20" stroke-linejoin="round"/>
+                    </defs>
+                    {% set driehoeken = [
+                        [80, 255, 15, 0.22, '#ffffff', 0.08],
+                        [170, 120, 250, 0.12, '#ff9dce', 0.12],
+                        [230, 35, 130, 0.18, '#8f004e', 0.22],
+                        [300, 175, 290, 0.15, '#ffffff', 0.07],
+                        [390, 275, 200, 0.25, '#ff9dce', 0.14],
+                        [450, 130, 20, 0.13, '#8f004e', 0.15],
+                        [520, 45, 75, 0.2, '#ffffff', 0.1],
+                        [590, 230, 220, 0.16, '#ff9dce', 0.16],
+                        [660, 110, 310, 0.28, '#8f004e', 0.25],
+                        [760, 35, 160, 0.32, '#ffffff', 0.12],
+                        [830, 250, 20, 0.26, '#ff9dce', 0.22],
+                        [910, 140, 245, 0.42, '#ffffff', 0.14],
+                        [1000, 35, 100, 0.28, '#8f004e', 0.3],
+                        [1030, 275, 180, 0.2, '#8f004e', 0.25],
+                        [1105, 200, 335, 0.48, '#ffffff', 0.16],
+                        [1170, 80, 60, 0.24, '#ff9dce', 0.28],
+                    ] %}
+                    {% for d in driehoeken %}
+                        <use href="#zwfm-driehoek" fill="{{ d[4] }}" stroke="{{ d[4] }}" opacity="{{ d[5] }}"
+                             transform="translate({{ d[0] }} {{ d[1] }}) rotate({{ d[2] }}) scale({{ d[3] }})"/>
+                    {% endfor %}
                 </svg>
             </div>
 
@@ -48,8 +62,8 @@
             </div>
         </header>
 
-        <div class="mx-auto max-w-960 px-4 pt-7 lg:grid lg:grid-cols-[1fr_20rem] lg:gap-11 lg:pt-9">
-            <div>
+        <div class="mx-auto max-w-960 px-4 pt-7 lg:grid lg:grid-cols-[1fr_20rem] lg:gap-x-11 lg:gap-y-8 lg:pt-9">
+            <div class="lg:col-start-1 lg:row-start-1">
                 {# Omschrijving #}
                 <div class="prose prose-lg dark:prose-invert mb-5">
                     {{ post.content }}
@@ -58,95 +72,16 @@
                 {# Rubrieken #}
                 {% set rubrieken = post.meta('fm_show_rubrieken') ?: [] %}
                 {% if rubrieken is not empty %}
-                    <div class="mb-9 flex flex-wrap gap-2">
+                    <div class="flex flex-wrap gap-2">
                         {% for rubriek in rubrieken %}
                             <span class="rounded-sm bg-gray-100 px-2 py-1 text-sm text-gray-900 dark:bg-gray-700 dark:text-gray-100">{{ rubriek.fm_show_rubriek_naam }}</span>
                         {% endfor %}
                     </div>
                 {% endif %}
-
-                {# Uitzending gemist #}
-                {% if gemist.days is not empty %}
-                    <section id="gemist" class="mb-8 rounded-sm bg-gray-800 p-4 text-white dark:border dark:border-gray-700/50">
-                        <div class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1">
-                            <h2 class="text-3xl font-bold">Uitzending gemist</h2>
-                            {% if gemist.days|length > 5 %}
-                                <div class="ml-auto flex items-center gap-1.5">
-                                    <button type="button" data-gemist-newer disabled aria-label="Nieuwere uitzendingen"
-                                            class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">‹</button>
-                                    <button type="button" data-gemist-older aria-label="Oudere uitzendingen"
-                                            class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">›</button>
-                                </div>
-                            {% endif %}
-                        </div>
-
-                        <ul class="flex flex-col gap-2 sm:grid sm:grid-cols-3 md:grid-cols-5">
-                            {% for day in gemist.days %}
-                                <li class="flex items-center gap-3 rounded-sm bg-gray-700/50 p-3 sm:block"
-                                    data-gemist-day{% if loop.index0 >= 5 %} style="display: none"{% endif %}>
-                                    <div class="flex-1 sm:mb-2.5 sm:flex-none">
-                                        <span class="text-sm font-semibold sm:hidden">{{ day.date.locale('nl').isoFormat('dddd D MMMM') }}</span>
-                                        <span class="hidden font-round text-xs font-bold tracking-wide text-gray-400 uppercase sm:block">{{ day.date.locale('nl').isoFormat('dd') }}</span>
-                                        <span class="hidden text-sm font-semibold sm:block">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
-                                    </div>
-                                    <div class="flex gap-1.5 sm:flex-col">
-                                        {% for time in day.times %}
-                                            <a class="rounded-sm bg-roze px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-roze/80 sm:px-0"
-                                               href="{{ options.radio_gemist_baseurl|replace({'<date>': time.format(options.radio_gemist_file)}) }}"
-                                               target="_blank" rel="noopener">▸ {{ time.locale('nl').isoFormat('HH:mm') }}</a>
-                                        {% endfor %}
-                                    </div>
-                                </li>
-                            {% endfor %}
-                        </ul>
-
-                        {% if gemist.retention_label %}
-                            <p class="mt-2.5 text-sm text-gray-400">Uitzendingen blijven {{ gemist.retention_label }} terug te luisteren.</p>
-                        {% endif %}
-
-                        <script>
-                            (function () {
-                                var section = document.getElementById('gemist');
-                                var newer = section.querySelector('[data-gemist-newer]');
-                                var older = section.querySelector('[data-gemist-older]');
-                                if (!newer || !older) {
-                                    return;
-                                }
-
-                                var days = section.querySelectorAll('[data-gemist-day]');
-                                var pageSize = 5;
-                                var pages = Math.ceil(days.length / pageSize);
-                                var page = 0;
-
-                                function render() {
-                                    days.forEach(function (day, i) {
-                                        var visible = i >= page * pageSize && i < (page + 1) * pageSize;
-                                        day.style.display = visible ? '' : 'none';
-                                    });
-                                    newer.disabled = page === 0;
-                                    older.disabled = page + 1 >= pages;
-                                }
-
-                                newer.addEventListener('click', function () {
-                                    if (page > 0) {
-                                        page--;
-                                        render();
-                                    }
-                                });
-                                older.addEventListener('click', function () {
-                                    if (page + 1 < pages) {
-                                        page++;
-                                        render();
-                                    }
-                                });
-                            })();
-                        </script>
-                    </section>
-                {% endif %}
             </div>
 
             {# Zijbalk #}
-            <aside class="mt-4 flex flex-col gap-4 lg:mt-0">
+            <aside class="mt-6 flex flex-col gap-4 lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:mt-0">
                 {% if presentatoren is not empty %}
                     <div class="rounded-sm border border-gray-800/10 bg-gray-50 p-4 dark:border-gray-200/10 dark:bg-gray-700/40">
                         <h2 class="mb-3.5 font-round text-sm font-bold tracking-wide text-gray-400 uppercase">De makers</h2>
@@ -196,9 +131,87 @@
                 {% endif %}
 
             </aside>
+
+            {# Uitzending gemist #}
+            {% if gemist.days is not empty %}
+                <section id="gemist" class="-mx-4 mt-6 bg-gray-800 p-4 text-white sm:mx-0 sm:rounded-sm lg:col-start-1 lg:row-start-2 lg:mt-0 dark:border dark:border-gray-700/50">
+                    <div class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-1">
+                        <h2 class="text-3xl font-bold">Uitzending gemist</h2>
+                        {% if gemist.days|length > 5 %}
+                            <div class="ml-auto flex items-center gap-1.5">
+                                <button type="button" data-gemist-newer disabled aria-label="Nieuwere uitzendingen"
+                                        class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">‹</button>
+                                <button type="button" data-gemist-older aria-label="Oudere uitzendingen"
+                                        class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">›</button>
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    <ul class="flex flex-col gap-2 sm:grid sm:grid-cols-3 md:grid-cols-5">
+                        {% for day in gemist.days %}
+                            <li class="flex items-center gap-3 rounded-sm bg-gray-700/50 p-3 sm:block"
+                                data-gemist-day{% if loop.index0 >= 5 %} style="display: none"{% endif %}>
+                                <div class="flex-1 sm:mb-2.5 sm:flex-none">
+                                    <span class="text-sm font-semibold sm:hidden">{{ day.date.locale('nl').isoFormat('dddd D MMMM') }}</span>
+                                    <span class="hidden font-round text-xs font-bold tracking-wide text-gray-400 uppercase sm:block">{{ day.date.locale('nl').isoFormat('dd') }}</span>
+                                    <span class="hidden text-sm font-semibold sm:block">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
+                                </div>
+                                <div class="flex gap-1.5 sm:flex-col">
+                                    {% for time in day.times %}
+                                        <a class="rounded-sm bg-roze px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-roze/80 sm:px-0"
+                                           href="{{ options.radio_gemist_baseurl|replace({'<date>': time.format(options.radio_gemist_file)}) }}"
+                                           target="_blank" rel="noopener">▸ {{ time.locale('nl').isoFormat('HH:mm') }}</a>
+                                    {% endfor %}
+                                </div>
+                            </li>
+                        {% endfor %}
+                    </ul>
+
+                    {% if gemist.retention_label %}
+                        <p class="mt-2.5 text-sm text-gray-400">Uitzendingen blijven {{ gemist.retention_label }} terug te luisteren.</p>
+                    {% endif %}
+
+                    <script>
+                        (function () {
+                            var section = document.getElementById('gemist');
+                            var newer = section.querySelector('[data-gemist-newer]');
+                            var older = section.querySelector('[data-gemist-older]');
+                            if (!newer || !older) {
+                                return;
+                            }
+
+                            var days = section.querySelectorAll('[data-gemist-day]');
+                            var pageSize = 5;
+                            var pages = Math.ceil(days.length / pageSize);
+                            var page = 0;
+
+                            function render() {
+                                days.forEach(function (day, i) {
+                                    var visible = i >= page * pageSize && i < (page + 1) * pageSize;
+                                    day.style.display = visible ? '' : 'none';
+                                });
+                                newer.disabled = page === 0;
+                                older.disabled = page + 1 >= pages;
+                            }
+
+                            newer.addEventListener('click', function () {
+                                if (page > 0) {
+                                    page--;
+                                    render();
+                                }
+                            });
+                            older.addEventListener('click', function () {
+                                if (page + 1 < pages) {
+                                    page++;
+                                    render();
+                                }
+                            });
+                        })();
+                    </script>
+                </section>
+            {% endif %}
         </div>
 
-        {# Meer programma's #}
         <div class="pb-8"></div>
     </article>
 {% endblock %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -158,9 +158,9 @@
                                 </div>
                                 <div class="flex gap-1.5 sm:flex-col">
                                     {% for time in day.times %}
-                                        <a class="rounded-sm bg-roze px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-roze/80 sm:px-0"
+                                        <a class="rounded-sm bg-gray-700 px-3 py-1.5 text-center text-xs font-bold text-white transition hover:bg-gray-600 sm:px-0"
                                            href="{{ options.radio_gemist_baseurl|replace({'<date>': time.format(options.radio_gemist_file)}) }}"
-                                           target="_blank" rel="noopener">▸ {{ time.locale('nl').isoFormat('HH:mm') }}</a>
+                                           target="_blank" rel="noopener">{{ time.locale('nl').isoFormat('HH:mm') }}</a>
                                     {% endfor %}
                                 </div>
                             </li>

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -6,20 +6,22 @@
 
     <article id="post-{{ post.id }}" class="{{ post.class }}">
         {# Hero #}
-        <header class="relative overflow-hidden bg-roze">
+        <header class="relative overflow-hidden bg-roze bg-gradient-to-r from-[#8f004e] via-[#c7006d] to-roze">
             <div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-                {# Uitzendgolven #}
-                <svg class="absolute top-1/2 -right-24 h-72 w-72 -translate-y-1/2 text-white md:-right-8 md:h-[26rem] md:w-[26rem]"
-                     viewBox="0 0 400 400" fill="none">
-                    <circle cx="200" cy="200" r="8" fill="currentColor" fill-opacity=".35"/>
-                    <circle cx="200" cy="200" r="60" stroke="currentColor" stroke-opacity=".3" stroke-width="2"/>
-                    <circle cx="200" cy="200" r="110" stroke="currentColor" stroke-opacity=".2" stroke-width="2"/>
-                    <circle cx="200" cy="200" r="160" stroke="currentColor" stroke-opacity=".12" stroke-width="2"/>
-                    <circle cx="200" cy="200" r="199" stroke="currentColor" stroke-opacity=".07" stroke-width="2"/>
+                {# Beeldmerk ZuidWest FM: linker- en onderdriehoek met ronde hoeken #}
+                <svg class="absolute top-1/2 -right-10 h-[135%] w-auto -translate-y-1/2 text-white opacity-10"
+                     viewBox="0 0 300 300">
+                    <g id="zwfm-merk" fill="currentColor" stroke="currentColor" stroke-width="10" stroke-linejoin="round">
+                        <path d="M91 7 L91 203 L7 105 Z"/>
+                        <path d="M97 215 L293 215 L195 293 Z"/>
+                    </g>
                 </svg>
-                {# Ruiten als extra lagen #}
-                <div class="absolute -right-10 -bottom-16 h-40 w-40 rotate-45 bg-white/10"></div>
-                <div class="absolute -top-10 right-40 h-24 w-24 rotate-45 bg-black/10 max-md:hidden"></div>
+                <svg class="absolute right-64 -bottom-8 h-28 w-28 text-[#8f004e] opacity-40 max-md:hidden" viewBox="0 0 300 300">
+                    <use href="#zwfm-merk"/>
+                </svg>
+                <svg class="absolute -top-6 right-40 h-20 w-20 rotate-180 text-[#ff9dce] opacity-30" viewBox="0 0 300 300">
+                    <use href="#zwfm-merk"/>
+                </svg>
             </div>
 
             <div class="relative mx-auto max-w-960 px-4 pt-6 pb-8 md:pt-7 md:pb-9">

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -1,58 +1,190 @@
 {% extends 'base.twig' %}
 
 {% block content %}
-    {% import 'partial/responsive-image.twig' as responsive %}
+    {% set presentatoren = get_users(post.meta('fm_show_presentator') ?: []) %}
+    {% set programmatie = post.meta('fm_show_programmatie') ?: [] %}
 
     <article id="post-{{ post.id }}" class="{{ post.class }}">
-        <div class="mx-auto max-w-960 md:px-4 md:pt-8">
-            <div class="aspect-[21/9] relative">
-                {% if post.thumbnail %}
-                    {{ responsive.render(
-                        src: post.thumbnail.src,
-                        width: 928,
-                        height: 928 / 21 * 9,
-                        sizes: '(min-width: 960px) 928px, (min-width: 768px) calc(100vw - 2rem), 100vw',
-                        alt: post.thumbnail.alt|default(post.title),
-                        class: 'absolute inset-0 w-full h-full object-cover bg-gray-200 dark:bg-gray-700',
-                        loading: 'eager',
-                    ) }}
+        {# Hero #}
+        <header class="relative overflow-hidden bg-gradient-to-r from-[#8f004e] via-[#c7006d] to-roze">
+            {% if post.thumbnail %}
+                <div class="absolute -right-10 -top-2 h-36 w-36 rotate-45 overflow-hidden rounded-2xl opacity-85 md:top-1/2 md:right-24 md:h-72 md:w-72 md:-translate-y-1/2 md:rounded-3xl"
+                     aria-hidden="true">
+                    <img src="{{ post.thumbnail.src|imgproxy(600, 600) }}" alt=""
+                         class="absolute top-1/2 left-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 -rotate-45 scale-150 object-cover opacity-45 mix-blend-luminosity">
+                </div>
+            {% endif %}
+
+            <div class="relative mx-auto max-w-960 px-4 pt-6 pb-8 md:pt-7 md:pb-9">
+                <nav class="mb-5 text-xs font-semibold text-white/70 md:text-sm" aria-label="Kruimelpad">
+                    <a class="underline decoration-white/40 underline-offset-2 hover:text-white"
+                       href="{{ function('get_post_type_archive_link', 'fm') }}">Alle FM-programma's</a>
+                    <span class="opacity-60">/</span>
+                    <span class="text-white">{{ post.title }}</span>
+                </nav>
+
+                {% if programmatie is not empty %}
+                    <div class="mb-3 flex flex-wrap gap-1.5">
+                        {% for entry in programmatie %}
+                            <span class="inline-flex items-center gap-2 rounded-full bg-white/15 px-3.5 py-1.5 text-xs font-bold text-white md:text-sm">
+                                <span class="h-1.5 w-1.5 rounded-full bg-white"></span>{{ entry|format_schedule_compact }}
+                            </span>
+                        {% endfor %}
+                    </div>
+                {% endif %}
+
+                <h1 class="font-round text-4xl leading-none font-black text-white uppercase md:text-5xl">{{ post.title }}</h1>
+
+                {% if presentatoren is not empty %}
+                    <p class="mt-2 text-sm text-white/85 md:text-base">Met {{ presentatoren|join(', ', ' en ') }}</p>
                 {% endif %}
             </div>
-        </div>
-        <div class="px-6 md:px-12 max-w-3xl mx-auto py-8">
-            <ul class="text-sm md:text-base text-black dark:text-white">
-                {% for entry in post.meta('fm_show_programmatie') %}
-                    <li>{{ entry|format_schedule }}</li>
-                {% endfor %}
-            </ul>
-            <h1 class="font-black font-round text-4xl md:text-5xl uppercase text-black dark:text-white">{{ post.title }}</h1>
+        </header>
 
-            <p class="text-sm md:text-base mb-8 text-black dark:text-white">Met {{ get_users(post.meta('fm_show_presentator') ?: [])|join(', ', ' en ') }}</p>
+        <div class="mx-auto max-w-960 px-4 pt-7 lg:grid lg:grid-cols-[1fr_20rem] lg:gap-11 lg:pt-9">
+            <div>
+                {# Omschrijving #}
+                <div class="prose prose-lg dark:prose-invert mb-5">
+                    {{ post.content }}
+                </div>
 
-            <div class="prose dark:prose-invert prose-lg sm:col-span-2">
-                {{ post.content }}
-            </div>
-        </div>
-
-        {% if recordings is not empty %}
-            <aside class="bg-gray-800 border-t border-transparent dark:border-gray-200/10 text-white">
-                <div class="w-full mx-auto max-w-960 px-4">
-                    <h2 class="font-bold text-3xl pt-4 pb-4">Uitzending gemist</h2>
-
-                    <ul class="grid grid-cols-2 md:grid-cols-4 gap-4 pb-4">
-                        {% for recording in recordings %}
-                            <li>
-                                <a class="block bg-gray-700/50 hover:bg-gray-700 focus:bg-gray-700 rounded-sm p-2"
-                                   href="{{ options.radio_gemist_baseurl|replace({'<date>': recording.format(options.radio_gemist_file)}) }}"
-                                   target="_blank">
-                                    <span class="block font-semibold">{{ recording.locale('nl').isoFormat('dddd D MMMM') }}</span>
-                                    <span class="block">{{ recording.locale('nl').isoFormat('HH:mm') }} uur</span>
-                                </a>
-                            </li>
+                {# Rubrieken #}
+                {% set rubrieken = post.meta('fm_show_rubrieken') ?: [] %}
+                {% if rubrieken is not empty %}
+                    <div class="mb-9 flex flex-wrap gap-2">
+                        {% for rubriek in rubrieken %}
+                            <span class="rounded-full bg-pink-100 px-3.5 py-1.5 text-xs font-bold text-[#b00061] dark:bg-roze/20 dark:text-pink-300">{{ rubriek.fm_show_rubriek_naam }}</span>
                         {% endfor %}
-                    </ul>
+                    </div>
+                {% endif %}
+
+                {# Uitzending gemist #}
+                {% if gemist.days is not empty %}
+                    <section id="gemist" class="mb-8 scroll-mt-32">
+                        <div class="mb-3.5 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                            <h2 class="text-2xl font-bold text-black dark:text-white">Uitzending gemist</h2>
+                            <div class="ml-auto flex items-center gap-2.5 text-sm font-bold">
+                                {% if gemist.week > 0 %}
+                                    <a class="text-roze hover:underline" href="?week={{ gemist.week - 1 }}#gemist">‹ nieuwer</a>
+                                {% endif %}
+                                <span class="text-gray-900 dark:text-white">
+                                    {%- if gemist.week == 0 -%}
+                                        deze week
+                                    {%- elseif gemist.week == 1 -%}
+                                        vorige week
+                                    {%- else -%}
+                                        {{ gemist.week }} weken terug
+                                    {%- endif -%}
+                                </span>
+                                {% if gemist.week + 1 < gemist.weeks %}
+                                    <a class="text-roze hover:underline" href="?week={{ gemist.week + 1 }}#gemist">{{ gemist.week == 0 ? 'vorige week' : 'ouder' }} ›</a>
+                                {% endif %}
+                            </div>
+                        </div>
+
+                        <ul class="sm:grid sm:grid-cols-3 sm:gap-2.5 md:grid-cols-5">
+                            {% for day in gemist.days %}
+                                <li class="flex items-center gap-3 border-t border-gray-200 py-3 sm:block sm:rounded-lg sm:border sm:p-3 dark:border-gray-600">
+                                    <div class="flex-1 sm:mb-2.5 sm:flex-none">
+                                        <span class="text-sm font-bold text-gray-900 sm:hidden dark:text-white">{{ day.date.locale('nl').isoFormat('dddd D MMMM') }}</span>
+                                        <span class="hidden text-xs font-bold tracking-wide text-gray-400 uppercase sm:block">{{ day.date.locale('nl').isoFormat('dd') }}</span>
+                                        <span class="hidden text-sm font-bold text-gray-900 sm:block dark:text-white">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
+                                    </div>
+                                    <div class="flex gap-1.5 sm:flex-col">
+                                        {% for time in day.times %}
+                                            <a class="rounded-full border-[1.5px] border-roze px-3 py-1.5 text-center text-xs font-bold text-roze transition hover:bg-roze hover:text-white sm:rounded-md sm:px-0"
+                                               href="{{ options.radio_gemist_baseurl|replace({'<date>': time.format(options.radio_gemist_file)}) }}"
+                                               target="_blank" rel="noopener">▸ {{ time.locale('nl').isoFormat('HH:mm') }}</a>
+                                        {% endfor %}
+                                    </div>
+                                </li>
+                            {% endfor %}
+                        </ul>
+
+                        {% if gemist.retention_label %}
+                            <p class="mt-2.5 text-sm text-gray-400">Uitzendingen blijven {{ gemist.retention_label }} terug te luisteren.</p>
+                        {% endif %}
+                    </section>
+                {% endif %}
+            </div>
+
+            {# Zijbalk #}
+            <aside class="mt-4 flex flex-col gap-4 lg:mt-0">
+                {% if presentatoren is not empty %}
+                    <div class="rounded-lg border border-gray-200 bg-gray-50 p-5 dark:border-gray-600 dark:bg-gray-700/40">
+                        <h2 class="mb-3.5 font-round text-xs font-bold tracking-wider text-gray-500 uppercase dark:text-gray-400">De makers</h2>
+                        <div class="flex flex-col gap-3.5">
+                            {% for maker in presentatoren %}
+                                <div class="flex gap-3">
+                                    <img src="{{ maker.avatar({size: 104}) }}" alt="{{ maker.name }}" width="52" height="52"
+                                         loading="lazy" class="h-13 w-13 flex-none rounded-full object-cover">
+                                    <div>
+                                        <p class="text-sm font-bold text-gray-900 dark:text-white">{{ maker.name }}</p>
+                                        {% if maker.meta('description') %}
+                                            <p class="text-xs leading-relaxed text-gray-500 dark:text-gray-400">{{ maker.meta('description') }}</p>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
+
+                {% if programmatie is not empty %}
+                    <div class="rounded-lg border border-gray-200 bg-gray-50 p-5 dark:border-gray-600 dark:bg-gray-700/40">
+                        <h2 class="mb-3 font-round text-xs font-bold tracking-wider text-gray-500 uppercase dark:text-gray-400">Uitzendschema</h2>
+                        <div class="mb-2.5 flex gap-1.5">
+                            {% for dayname, label in {maandag: 'ma', dinsdag: 'di', woensdag: 'wo', donderdag: 'do', vrijdag: 'vr', zaterdag: 'za', zondag: 'zo'} %}
+                                <span class="flex-1 rounded py-1.5 text-center text-xs font-bold {{ dayname in schedule_days ? 'bg-roze text-white' : 'bg-gray-200 text-gray-400 dark:bg-gray-600 dark:text-gray-400' }}">{{ label }}</span>
+                            {% endfor %}
+                        </div>
+                        {% if programmatie|length == 1 %}
+                            <p class="text-xl font-black text-gray-900 dark:text-white">{{ programmatie[0].fm_show_starttijd|slice(0, 5) }} – {{ programmatie[0].fm_show_eindtijd|slice(0, 5) }}</p>
+                        {% else %}
+                            {% for entry in programmatie %}
+                                <p class="text-sm font-bold text-gray-900 dark:text-white">{{ entry|format_schedule_compact }}</p>
+                            {% endfor %}
+                        {% endif %}
+                        {% if following_show %}
+                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Aansluitend: {{ following_show.name }}</p>
+                        {% endif %}
+                    </div>
+                {% endif %}
+
+                <div class="rounded-lg bg-gray-800 p-5 text-white dark:border dark:border-gray-600 dark:bg-gray-900">
+                    <h2 class="mb-2.5 font-round text-xs font-bold tracking-wider text-gray-400 uppercase">Ook luisteren?</h2>
+                    <p class="text-sm leading-relaxed text-gray-300">
+                        {% if options.radio_frequenties %}
+                            {% for channel in options.radio_frequenties %}
+                                {{- channel.radio_frequenties_medium }} {{ channel.radio_frequenties_frequentie }}{{ not loop.last ? ' · ' -}}
+                            {% endfor %}
+                            <br>
+                        {% endif %}
+                        of via de <a class="underline hover:text-white" href="{{ site.url }}/?pswutlzoq=install">ZuidWest App</a>
+                    </p>
+                    {% if fm_player_page %}
+                        <a class="mt-3 inline-block rounded bg-roze px-4 py-2 text-sm font-bold text-white transition hover:bg-[#b00061]"
+                           href="{{ fm_player_page.link }}">▸ Luister live</a>
+                    {% endif %}
                 </div>
             </aside>
+        </div>
+
+        {# Meer programma's #}
+        {% if other_shows is not empty %}
+            <div class="mx-auto max-w-960 px-4">
+                <div class="mt-7 flex flex-wrap items-center gap-3 border-t border-gray-200 py-4 pb-6 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                    <span class="font-bold text-gray-900 dark:text-white">Meer FM-programma's:</span>
+                    {% for show in other_shows|slice(0, 4) %}
+                        <a class="rounded-full border border-gray-200 px-3 py-1 font-semibold transition hover:border-roze hover:text-roze dark:border-gray-600"
+                           href="{{ show.link }}">{{ show.title }}</a>
+                    {% endfor %}
+                    <a class="font-bold text-roze hover:underline md:ml-auto"
+                       href="{{ function('get_post_type_archive_link', 'fm') }}">Alle programma's →</a>
+                </div>
+            </div>
+        {% else %}
+            <div class="pb-8"></div>
         {% endif %}
     </article>
 {% endblock %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -150,22 +150,6 @@
                     </div>
                 {% endif %}
 
-                <div class="rounded-lg bg-gray-800 p-5 text-white dark:border dark:border-gray-600 dark:bg-gray-900">
-                    <h2 class="mb-2.5 font-round text-xs font-bold tracking-wider text-gray-400 uppercase">Ook luisteren?</h2>
-                    <p class="text-sm leading-relaxed text-gray-300">
-                        {% if options.radio_frequenties %}
-                            {% for channel in options.radio_frequenties %}
-                                {{- channel.radio_frequenties_medium }} {{ channel.radio_frequenties_frequentie }}{{ not loop.last ? ' · ' -}}
-                            {% endfor %}
-                            <br>
-                        {% endif %}
-                        of via de <a class="underline hover:text-white" href="{{ site.url }}/?pswutlzoq=install">ZuidWest App</a>
-                    </p>
-                    {% if fm_player_page %}
-                        <a class="mt-3 inline-block rounded bg-roze px-4 py-2 text-sm font-bold text-white transition hover:bg-[#b00061]"
-                           href="{{ fm_player_page.link }}">▸ Luister live</a>
-                    {% endif %}
-                </div>
             </aside>
         </div>
 

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -180,7 +180,7 @@
                                 data-gemist-day{% if loop.index0 >= 5 %} style="display: none"{% endif %}>
                                 <div class="flex-1 sm:mb-2.5 sm:flex-none">
                                     <span class="text-sm font-semibold sm:hidden">{{ day.date.locale('nl').isoFormat('dddd D MMMM') }}</span>
-                                    <span class="hidden font-round text-xs font-bold tracking-wide text-gray-400 uppercase sm:block">{{ day.date.locale('nl').isoFormat('dd') }}</span>
+                                    <span class="hidden font-round text-xs font-bold tracking-wide text-gray-400 uppercase sm:block">{{ day.date.locale('nl').isoFormat('dddd') }}</span>
                                     <span class="hidden text-sm font-semibold sm:block">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
                                 </div>
                                 <div class="flex gap-1.5 sm:flex-col">

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -64,11 +64,11 @@
             </div>
 
             <div class="relative mx-auto max-w-960 px-4 pt-6 pb-8 md:pt-7 md:pb-9">
-                <nav class="mb-5 text-xs font-semibold text-white/70 md:text-sm" aria-label="Kruimelpad">
-                    <a class="underline decoration-white/40 underline-offset-2 hover:text-white"
+                <nav class="mb-5 text-xs font-medium text-white/50" aria-label="Kruimelpad">
+                    <a class="transition hover:text-white hover:underline"
                        href="{{ function('get_post_type_archive_link', 'fm') }}">Alle FM-programma's</a>
-                    <span class="opacity-60">/</span>
-                    <span class="text-white">{{ post.title }}</span>
+                    <span class="opacity-60">{{ breadcrumb_separator }}</span>
+                    <span class="text-white/60">{{ post.title }}</span>
                 </nav>
 
                 {% if programmatie is not empty %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -1,8 +1,16 @@
 {% extends 'base.twig' %}
 
+{% macro driehoeken(items) %}
+    {% for d in items %}
+        <use href="#zwfm-driehoek" fill="{{ d[4] }}" stroke="{{ d[4] }}" opacity="{{ d[5] }}"
+             transform="translate({{ d[0] }} {{ d[1] }}) rotate({{ d[2] }}) scale({{ d[3] }})"/>
+    {% endfor %}
+{% endmacro %}
+
 {% block content %}
     {% set presentatoren = get_users(post.meta('fm_show_presentator') ?: []) %}
-    {% set programmatie = post.meta('fm_show_programmatie') ?: [] %}
+    {% set card = 'rounded-sm border border-gray-800/10 bg-gray-50 p-4 dark:border-gray-200/10 dark:bg-gray-700/40' %}
+    {% set card_title = 'mb-3 font-round text-sm font-bold tracking-wide text-gray-400 uppercase' %}
 
     <article id="post-{{ post.id }}" class="{{ post.class }}">
         {# Hero #}
@@ -18,7 +26,7 @@
                     </defs>
                 </svg>
                 <svg class="absolute inset-0 h-full w-full max-md:hidden" viewBox="0 0 1200 300" preserveAspectRatio="xMidYMid slice">
-                    {% set driehoeken = [
+                    {{ _self.driehoeken([
                         [80, 255, 15, 0.22, '#ffffff', 0.08],
                         [170, 120, 250, 0.12, '#ff9dce', 0.12],
                         [230, 35, 130, 0.18, '#8f004e', 0.22],
@@ -35,15 +43,11 @@
                         [1030, 275, 180, 0.2, '#8f004e', 0.25],
                         [1105, 200, 335, 0.48, '#ffffff', 0.16],
                         [1170, 80, 60, 0.24, '#ff9dce', 0.28],
-                    ] %}
-                    {% for d in driehoeken %}
-                        <use href="#zwfm-driehoek" fill="{{ d[4] }}" stroke="{{ d[4] }}" opacity="{{ d[5] }}"
-                             transform="translate({{ d[0] }} {{ d[1] }}) rotate({{ d[2] }}) scale({{ d[3] }})"/>
-                    {% endfor %}
+                    ]) }}
                 </svg>
                 {# Mobiel is de header smal en hoog; eigen compositie zodat de driehoeken niet wegvallen door de slice-crop #}
                 <svg class="absolute inset-0 h-full w-full md:hidden" viewBox="0 0 390 220" preserveAspectRatio="xMidYMid slice">
-                    {% set driehoeken_mobiel = [
+                    {{ _self.driehoeken([
                         [30, 110, 330, 0.14, '#8f004e', 0.22],
                         [48, 198, 20, 0.18, '#ffffff', 0.14],
                         [95, 52, 140, 0.15, '#ff9dce', 0.22],
@@ -55,11 +59,7 @@
                         [315, 55, 225, 0.22, '#ffffff', 0.16],
                         [360, 145, 30, 0.24, '#ff9dce', 0.3],
                         [374, 18, 190, 0.16, '#8f004e', 0.26],
-                    ] %}
-                    {% for d in driehoeken_mobiel %}
-                        <use href="#zwfm-driehoek" fill="{{ d[4] }}" stroke="{{ d[4] }}" opacity="{{ d[5] }}"
-                             transform="translate({{ d[0] }} {{ d[1] }}) rotate({{ d[2] }}) scale({{ d[3] }})"/>
-                    {% endfor %}
+                    ]) }}
                 </svg>
             </div>
 
@@ -108,8 +108,8 @@
             {# Zijbalk #}
             <aside class="mt-6 flex flex-col gap-4 lg:mt-0">
                 {% if presentatoren is not empty %}
-                    <div class="rounded-sm border border-gray-800/10 bg-gray-50 p-4 dark:border-gray-200/10 dark:bg-gray-700/40">
-                        <h2 class="mb-3.5 font-round text-sm font-bold tracking-wide text-gray-400 uppercase">De makers</h2>
+                    <div class="{{ card }}">
+                        <h2 class="{{ card_title }}">De makers</h2>
                         <div class="flex flex-col gap-3.5">
                             {% for maker in presentatoren %}
                                 <div class="flex gap-3">
@@ -130,11 +130,11 @@
                 {% endif %}
 
                 {% if programmatie is not empty %}
-                    <div class="rounded-sm border border-gray-800/10 bg-gray-50 p-4 dark:border-gray-200/10 dark:bg-gray-700/40">
-                        <h2 class="mb-3 font-round text-sm font-bold tracking-wide text-gray-400 uppercase">Uitzendschema</h2>
+                    <div class="{{ card }}">
+                        <h2 class="{{ card_title }}">Uitzendschema</h2>
                         <div class="mb-2.5 flex gap-1.5">
-                            {% for dayname, label in {maandag: 'ma', dinsdag: 'di', woensdag: 'wo', donderdag: 'do', vrijdag: 'vr', zaterdag: 'za', zondag: 'zo'} %}
-                                <span class="flex-1 rounded-sm py-1.5 text-center text-xs font-bold {{ dayname in schedule_days ? 'bg-roze text-white' : 'bg-gray-200 text-gray-400 dark:bg-gray-600 dark:text-gray-400' }}">{{ label }}</span>
+                            {% for dayname in weekday_names %}
+                                <span class="flex-1 rounded-sm py-1.5 text-center text-xs font-bold {{ dayname in schedule_days ? 'bg-roze text-white' : 'bg-gray-200 text-gray-400 dark:bg-gray-600 dark:text-gray-400' }}">{{ dayname|slice(0, 2) }}</span>
                             {% endfor %}
                         </div>
                         {% if programmatie|length == 1 %}
@@ -168,9 +168,9 @@
                         <h2 class="text-3xl font-bold">Uitzending gemist</h2>
                         <div class="ml-auto flex items-center gap-1.5" data-gemist-nav hidden>
                             <button type="button" data-gemist-newer disabled aria-label="Nieuwere uitzendingen"
-                                    class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">‹</button>
+                                    class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">{{ icon('icon-arrow_back') }}</button>
                             <button type="button" data-gemist-older aria-label="Oudere uitzendingen"
-                                    class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 font-bold transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">›</button>
+                                    class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">{{ icon('icon-arrow_forward') }}</button>
                         </div>
                     </div>
 
@@ -210,12 +210,11 @@
                             }
 
                             function update() {
+                                var tolerance = 4;
                                 var max = track.scrollWidth - track.clientWidth;
-                                var last = track.lastElementChild;
-                                nav.hidden = max <= 4;
-                                newer.disabled = track.scrollLeft <= 4;
-                                older.disabled = !last
-                                    || last.getBoundingClientRect().right <= track.getBoundingClientRect().right + 4;
+                                nav.hidden = max <= tolerance;
+                                newer.disabled = track.scrollLeft <= tolerance;
+                                older.disabled = track.scrollLeft >= max - tolerance;
                             }
 
                             newer.addEventListener('click', function () {


### PR DESCRIPTION
Follow-up to #196. The theme had two separate prev/next carousel implementations: the new vanilla one on the "Uitzending gemist" section and the jQuery one in the dossiers carousel. The latter also relied on a plugin happening to load jQuery on the front end; the theme itself never enqueues it.

- New `templates/partial/scroller.twig`: initializes itself once per page and binds every `[data-scroller]` with `[data-scroller-track]`, `[data-scroller-prev/next]` and an optional `[data-scroller-nav]`
- The page size is the track width minus `scroll-padding`, so carousels with insets (like the dossiers one) no longer overscroll on wide screens
- The gemist section uses the partial instead of its own inline script
- Dossiers carousel migrated: jQuery script removed, the existing buttons and shims wired up via data attributes, buttons hide at both ends and cards snap to the grid
- Because the partial scopes per `[data-scroller]`, multiple dossier blocks on one page no longer steer each other (the old `$('.slider')` selector did)

Based on `feature/single-fm-redesign` because the gemist carousel lives there; once #196 merges, GitHub retargets this PR to `main` automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added smoother horizontal scrolling with snap-to-item behavior for dossier and “Uitzending gemist” carousels.
  - Added consistent previous/next navigation with automatic button states.
  - Navigation controls now hide when no additional content is available.
  - Carousel positioning stays synchronized when users scroll or resize the window.

- **Refactor**
  - Standardized carousel interactions across dossier and broadcast sections for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->