### PR TITLE
fix: align carousel paging with content insets

### DIFF
--- a/static/site.js
+++ b/static/site.js
@@ -26,7 +26,7 @@ document.querySelectorAll('[data-scroller]').forEach(function (scroller) {
         const style = getComputedStyle(track);
         const padding = (parseFloat(style.scrollPaddingLeft) || 0)
             + (parseFloat(style.scrollPaddingRight) || 0);
-        return track.clientWidth - padding;
+        return Math.max(track.clientWidth - padding, 0);
     }
     function update() {
         const max = track.scrollWidth - track.clientWidth;

--- a/static/site.js
+++ b/static/site.js
@@ -22,14 +22,20 @@ document.querySelectorAll('[data-scroller]').forEach(function (scroller) {
     if (!track || !nav || !prev || !next) {
         return;
     }
+    function pageSize() {
+        const style = getComputedStyle(track);
+        const padding = (parseFloat(style.scrollPaddingLeft) || 0)
+            + (parseFloat(style.scrollPaddingRight) || 0);
+        return track.clientWidth - padding;
+    }
     function update() {
         const max = track.scrollWidth - track.clientWidth;
         nav.hidden = max <= 4;
         prev.disabled = track.scrollLeft <= 4;
         next.disabled = track.scrollLeft >= max - 4;
     }
-    prev.onclick = () => track.scrollBy({left: -track.clientWidth, behavior: 'smooth'});
-    next.onclick = () => track.scrollBy({left: track.clientWidth, behavior: 'smooth'});
+    prev.onclick = () => track.scrollBy({left: -pageSize(), behavior: 'smooth'});
+    next.onclick = () => track.scrollBy({left: pageSize(), behavior: 'smooth'});
     track.addEventListener('scroll', update, {passive: true});
     window.addEventListener('resize', update);
     update();

--- a/templates/blocks/blok_dossiers_carrousel.twig
+++ b/templates/blocks/blok_dossiers_carrousel.twig
@@ -25,7 +25,8 @@
     <div class="mx-auto max-w-960 px-4">
         <h2 class="pb-4 text-3xl font-bold dark:text-white">Dossiers</h2>
     </div>
-    <div class="scroll-smooth overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" data-scroller-track>
+    <div class="snap-x snap-proximity scroll-smooth overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+         data-scroller-track style="scroll-padding-inline:var(--grid-inset)">
         <div class="flex w-max">
             <div class="flex-none" style="width:var(--grid-inset)"></div>
             {% for term in block.terms %}

--- a/templates/blocks/blok_dossiers_carrousel.twig
+++ b/templates/blocks/blok_dossiers_carrousel.twig
@@ -2,8 +2,7 @@
 
 {% macro render_term(term) %}
     <a href="{{ term.link }}"
-       class="flex-none snap-start overflow-hidden rounded-sm bg-gray-800"
-       style="width:calc((var(--grid-container) - var(--grid-gutter) * (var(--grid-columns) - 1)) / var(--grid-columns));min-width:140px;margin:0 calc(var(--grid-gutter) / 2)">
+       class="w-(--grid-item) min-w-35 flex-none snap-start overflow-hidden rounded-sm bg-gray-800">
         <div class="relative aspect-[9/16]">
             {% set image = get_image(term.meta('dossier_afbeelding_hoog')) %}
             {{ responsive.render(
@@ -21,27 +20,23 @@
 {% endmacro %}
 
 <section class="relative py-4 [--grid-columns:3] sm:[--grid-columns:4] dark:border-t dark:border-gray-700/50" data-scroller
-         style="--grid-container:calc(min(100vw, 60rem) - 2rem);--grid-gutter:.5rem;--grid-inset:calc((100vw - var(--grid-container)) / 2 - var(--grid-gutter) / 2)">
+         style="--grid-container:calc(min(100vw, 60rem) - 2rem);--grid-gutter:.5rem;--grid-inset:calc((100vw - var(--grid-container)) / 2);--grid-item:calc((var(--grid-container) - var(--grid-gutter) * (var(--grid-columns) - 1)) / var(--grid-columns))">
     <div class="mx-auto max-w-960 px-4">
         <h2 class="pb-4 text-3xl font-bold dark:text-white">Dossiers</h2>
     </div>
-    <div class="snap-x snap-proximity scroll-smooth overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-         data-scroller-track style="scroll-padding-inline:var(--grid-inset)">
-        <div class="flex w-max">
-            <div class="flex-none" style="width:var(--grid-inset)"></div>
-            {% for term in block.terms %}
-                {{ _self.render_term(term) }}
-            {% endfor %}
-            <div class="flex-none" style="width:var(--grid-inset)"></div>
-        </div>
+    <div class="flex snap-x snap-proximity gap-(--grid-gutter) overflow-x-auto px-(--grid-inset) scroll-px-(--grid-inset) [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+         data-scroller-track>
+        {% for term in block.terms %}
+            {{ _self.render_term(term) }}
+        {% endfor %}
     </div>
     <div data-scroller-nav hidden>
         <button type="button" data-scroller-prev disabled aria-label="Vorige dossiers"
-                class="group absolute inset-y-0 left-0 hidden w-[var(--grid-inset)] bg-white/50 transition hover:bg-white/70 disabled:cursor-default dark:bg-gray-800/50 dark:hover:bg-gray-800/70 [@media(pointer:fine)]:block">
+                class="group absolute inset-y-0 left-0 hidden w-(--grid-inset) bg-white/50 transition hover:bg-white/70 disabled:cursor-default dark:bg-gray-800/50 dark:hover:bg-gray-800/70 [@media(pointer:fine)]:block">
             <span class="absolute top-1/2 right-0 flex h-16 w-16 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white text-gray-800 shadow-lg">{{ icon('icon-arrow_back') }}</span>
         </button>
         <button type="button" data-scroller-next aria-label="Volgende dossiers"
-                class="group absolute inset-y-0 right-0 hidden w-[var(--grid-inset)] bg-white/50 transition hover:bg-white/70 disabled:cursor-default dark:bg-gray-800/50 dark:hover:bg-gray-800/70 [@media(pointer:fine)]:block">
+                class="group absolute inset-y-0 right-0 hidden w-(--grid-inset) bg-white/50 transition hover:bg-white/70 disabled:cursor-default dark:bg-gray-800/50 dark:hover:bg-gray-800/70 [@media(pointer:fine)]:block">
             <span class="absolute top-1/2 left-0 flex h-16 w-16 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white text-gray-800 shadow-lg">{{ icon('icon-arrow_forward') }}</span>
         </button>
     </div>

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -143,8 +143,8 @@
                         </div>
                     </div>
 
-                    <ul class="-mx-4 flex snap-x snap-proximity gap-3 overflow-x-auto px-4 py-1 sm:gap-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-                        data-scroller-track style="scroll-padding-left: 1rem">
+                    <ul class="-mx-4 flex snap-x snap-proximity gap-3 overflow-x-auto px-4 py-1 scroll-px-4 sm:gap-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                        data-scroller-track>
                         {% for day in gemist.days %}
                             <li class="w-28 flex-none snap-start rounded-sm bg-gray-700/50 p-3 text-center sm:w-44 sm:p-4">
                                 <span class="block font-round text-xs font-bold tracking-wide text-gray-400 uppercase">


### PR DESCRIPTION
## What

Follow-up to #196, superseding #198 with a clean change based directly on `main`.

- Calculate carousel page size from the track width minus its horizontal scroll padding
- Give the dossiers carousel scroll padding matching its visual grid insets
- Restore proximity snapping so each arrow click lands on the next complete group of cards
- Keep the shared scroller implementation in `static/site.js` and the compact dossier markup introduced by #196

## Why

On viewports wider than the 960px content grid, the dossiers carousel paged by the full viewport width. The covered side insets counted toward that distance, so one or more dossier cards could be skipped. At 1200px, for example, the old step was 1200px while the four-card content page is 936px.

## Tested

- `composer lint:twig`
- `vendor/bin/phpcs --standard=phpcs.xml .`
- `node --check static/site.js`
- `npm run build:tailwind`
- Targeted JavaScript assertions for dossier and gemist page sizes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved horizontal carousel previous/next behavior to scroll by the exact visible “page” width, accounting for left/right scroll padding and using smooth scrolling.
  * Updated dossier carousels to use snap-based horizontal scrolling for more consistent item alignment.
  * Refined the “Uitzending gemist” scroller markup by adjusting the scroll-padding setup and making the scrolling container structure more direct for improved horizontal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->