### PR TITLE
chore: remove dead jQuery enqueue on regio archive

### DIFF
--- a/taxonomy-regio.php
+++ b/taxonomy-regio.php
@@ -18,5 +18,4 @@ $context['news'] = Timber::get_posts([
     ]
 ]);
 
-wp_enqueue_script('jquery');
 Timber::render(['regio.twig'], $context);


### PR DESCRIPTION
## Summary

Removes the last front-end jQuery usage from the theme: a leftover `wp_enqueue_script('jquery')` in `taxonomy-regio.php`.

The enqueue was added in 2021 (702480a) for the former front page template and was carried along to the regio archive during later refactors. Nothing on the front end uses jQuery anymore - `static/site.js` and all Twig templates are vanilla JS (verified with a sweep for `jQuery` and `$(` across templates and static assets). The line only loaded ~30KB (gzipped) of jQuery on regio archive pages for nothing.

The two remaining jQuery usages in `lib/taxonomy_ranking.php` and `lib/push_adapter.php` are intentionally left alone: they run in classic-editor Publish metaboxes in wp-admin, where WordPress core always loads jQuery anyway.

## Test plan

- `./vendor/bin/phpcs taxonomy-regio.php` passes
- Verified no template rendered on the regio archive (`regio.twig`, `base.twig`, partials) references jQuery