### PR TITLE
fix: align carousel paging and FM schedule labels

### DIFF
--- a/src/Site.php
+++ b/src/Site.php
@@ -98,12 +98,13 @@ class Site extends \Timber\Site
         $names = array_values(BroadcastDay::WEEKDAY_NAMES);
         $days = array_values(array_intersect($names, $entry['fm_show_dagen'] ?: []));
         $positions = array_flip($names);
-        $short = fn ($day) => strtoupper(substr($day, 0, 2));
+        $short = fn ($day) => substr($day, 0, 2);
         $label = match (true) {
-            count($days) === 7 => 'ELKE DAG',
-            $days === array_slice($names, 0, 5) => 'ELKE WERKDAG',
+            count($days) === 7 => 'elke dag',
+            $days === array_slice($names, 0, 5) => 'elke werkdag',
+            count($days) === 2 => implode(' en ', array_map($short, $days)),
             count($days) >= 3 && $days === array_slice($names, $positions[$days[0]], count($days))
-            => $short($days[0]) . ' T/M ' . $short(end($days)),
+            => $short($days[0]) . ' t/m ' . $short(end($days)),
             default => implode(', ', array_map($short, $days)),
         };
 

--- a/static/site.js
+++ b/static/site.js
@@ -16,6 +16,7 @@ document.querySelectorAll('[data-theme]').forEach(function (button) {
 initDarkMode();
 
 // Share paging and disabled-state handling across every horizontal carousel.
+const SCROLLER_TOLERANCE = 4;
 document.querySelectorAll('[data-scroller]').forEach(function (scroller) {
     const find = (part) => scroller.querySelector(`[data-scroller-${part}]`);
     const [track, nav, prev, next] = ['track', 'nav', 'prev', 'next'].map(find);
@@ -24,22 +25,27 @@ document.querySelectorAll('[data-scroller]').forEach(function (scroller) {
     }
     function pageSize() {
         const style = getComputedStyle(track);
-        const item = track.querySelector('[data-scroller-item]');
-        const columns = parseInt(getComputedStyle(scroller).getPropertyValue('--grid-columns'), 10);
-        if (item && columns) {
-            const gap = parseFloat(style.columnGap) || 0;
-            return (item.getBoundingClientRect().width + gap) * columns;
-        }
-
         const padding = (parseFloat(style.scrollPaddingLeft) || 0)
             + (parseFloat(style.scrollPaddingRight) || 0);
-        return Math.max(track.clientWidth - padding, 0);
+        const visible = Math.max(track.clientWidth - padding, 0);
+        const item = track.firstElementChild;
+        if (!item) {
+            return visible;
+        }
+        // Page by whole item strides so paging lands on the snap grid; the
+        // last visible item has no trailing gap, hence the gap credit.
+        const gap = parseFloat(style.columnGap) || 0;
+        const stride = item.getBoundingClientRect().width + gap;
+        if (stride <= 0) {
+            return visible;
+        }
+        return stride * Math.max(1, Math.floor((visible + gap + SCROLLER_TOLERANCE) / stride));
     }
     function update() {
         const max = track.scrollWidth - track.clientWidth;
-        nav.hidden = max <= 4;
-        prev.disabled = track.scrollLeft <= 4;
-        next.disabled = track.scrollLeft >= max - 4;
+        nav.hidden = max <= SCROLLER_TOLERANCE;
+        prev.disabled = track.scrollLeft <= SCROLLER_TOLERANCE;
+        next.disabled = track.scrollLeft >= max - SCROLLER_TOLERANCE;
     }
     prev.onclick = () => track.scrollBy({left: -pageSize(), behavior: 'smooth'});
     next.onclick = () => track.scrollBy({left: pageSize(), behavior: 'smooth'});

--- a/templates/blocks/blok_dossiers_carrousel.twig
+++ b/templates/blocks/blok_dossiers_carrousel.twig
@@ -2,7 +2,6 @@
 
 {% macro render_term(term) %}
     <a href="{{ term.link }}"
-       data-scroller-item
        class="w-(--grid-item) min-w-35 flex-none snap-start overflow-hidden rounded-sm bg-gray-800">
         <div class="relative aspect-[9/16]">
             {% set image = get_image(term.meta('dossier_afbeelding_hoog')) %}
@@ -25,7 +24,7 @@
     <div class="mx-auto max-w-960 px-4">
         <h2 class="pb-4 text-3xl font-bold dark:text-white">Dossiers</h2>
     </div>
-    <div class="flex snap-x snap-proximity gap-(--grid-gutter) overflow-x-auto px-(--grid-inset) scroll-px-(--grid-inset) [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+    <div class="flex snap-x snap-proximity gap-(--grid-gutter) overflow-x-auto scrollbar-none px-(--grid-inset) scroll-px-(--grid-inset)"
          data-scroller-track>
         {% for term in block.terms %}
             {{ _self.render_term(term) }}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -143,7 +143,7 @@
                         </div>
                     </div>
 
-                    <ul class="-mx-4 flex snap-x snap-proximity gap-3 overflow-x-auto px-4 py-1 scroll-px-4 sm:gap-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                    <ul class="-mx-4 flex snap-x snap-proximity gap-3 overflow-x-auto scrollbar-none px-4 py-1 scroll-px-4 sm:gap-4"
                         data-scroller-track>
                         {% for day in gemist.days %}
                             <li class="w-28 flex-none snap-start rounded-sm bg-gray-700/50 p-3 text-center sm:w-44 sm:p-4">


### PR DESCRIPTION
## Summary

- Page the dossier and FM missed-broadcast carousels by whole visible item strides using their rendered widths, gaps, and scroll padding.
- Replace the custom scrollbar-hiding selectors with the Tailwind CSS 4.3 `scrollbar-none` utility.
- Join exactly two FM broadcast days with `en` and leave capitalization to the existing `uppercase` presentation classes.

## User-visible impact

Carousel controls now land consistently on complete cards across responsive widths. FM programs scheduled on two days display labels such as `ZA EN ZO VAN 16:00 TOT 18:00 UUR`.

## Verification

- `node --check static/site.js`
- `composer lint:twig`
- `php -l src/Site.php`
- `vendor/bin/phpcs --standard=phpcs.xml src/Site.php`
- `npm run build:tailwind`
- Verified representative mobile and desktop paging calculations for both carousels.

## Assumptions

Carousel tracks contain equal-width direct child items. WordPress 6.9+, PHP 8.3+, and Tailwind CSS 4.3 remain the target environment.

No screenshots are included because this preserves the existing carousel and control design; the visible changes are paging behavior and schedule copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Schedule labels now use a more consistent lowercase format.
  * Horizontal carousels page more smoothly and align better with visible items.
  * Carousel navigation controls now respond more accurately at the beginning and end of content.
  * Scrollbars are hidden consistently across supported browsers for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->