### PR TITLE
refactor: share carousel shell and controls

### DIFF
--- a/templates/blocks/blok_dossiers_carrousel.twig
+++ b/templates/blocks/blok_dossiers_carrousel.twig
@@ -1,43 +1,33 @@
-{% import 'partial/responsive-image.twig' as responsive %}
-
-{% macro render_term(term) %}
-    <a href="{{ term.link }}"
-       class="w-(--grid-item) min-w-35 flex-none snap-start overflow-hidden rounded-sm bg-gray-800">
-        <div class="relative aspect-[9/16]">
-            {% set image = get_image(term.meta('dossier_afbeelding_hoog')) %}
-            {{ responsive.render(
-                src: image.src,
-                width: 226,
-                height: 402,
-                sizes: '(min-width: 960px) 226px, (min-width: 640px) calc((100vw - 3.5rem) / 4), calc((100vw - 3rem) / 3)',
-                alt: image.alt|default(term.title),
-                class: 'absolute inset-0 w-full',
-            ) }}
-            <i class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black opacity-60"></i>
-            <h2 class="absolute inset-x-0 bottom-0 p-4 text-center text-md font-black text-white sm:text-xl">{{ term.title }}</h2>
-        </div>
-    </a>
-{% endmacro %}
-
-<section class="relative py-4 [--grid-columns:3] sm:[--grid-columns:4] dark:border-t dark:border-gray-700/50" data-scroller
-         style="--grid-container:calc(min(100vw, 60rem) - 2rem);--grid-gutter:.5rem;--grid-inset:calc((100vw - var(--grid-container)) / 2);--grid-item:calc((var(--grid-container) - var(--grid-gutter) * (var(--grid-columns) - 1)) / var(--grid-columns))">
-    <div class="mx-auto max-w-960 px-4">
-        <h2 class="pb-4 text-3xl font-bold dark:text-white">Dossiers</h2>
-    </div>
-    <div class="flex snap-x snap-proximity gap-(--grid-gutter) overflow-x-auto scrollbar-none px-(--grid-inset) scroll-px-(--grid-inset)"
-         data-scroller-track>
-        {% for term in block.terms %}
-            {{ _self.render_term(term) }}
+{% embed 'partial/carousel.twig' with {
+    id: 'dossiers',
+    title: 'Dossiers',
+    previous_label: 'Vorige dossiers',
+    next_label: 'Volgende dossiers',
+    root_class: 'py-4 [--grid-columns:3] sm:[--grid-columns:4] dark:border-t dark:border-gray-700/50',
+    root_style: '--grid-container:calc(min(100vw, 60rem) - 2rem);--grid-gutter:.5rem;--grid-inset:calc((100vw - var(--grid-container)) / 2);--grid-item:calc((var(--grid-container) - var(--grid-gutter) * (var(--grid-columns) - 1)) / var(--grid-columns))',
+    title_class: 'dark:text-white',
+    track_class: 'gap-(--grid-gutter) px-(--grid-inset) scroll-px-(--grid-inset)',
+    terms: block.terms,
+} %}
+    {% block items %}
+        {% import 'partial/responsive-image.twig' as responsive %}
+        {% for term in terms %}
+            <a href="{{ term.link }}"
+               class="w-(--grid-item) min-w-35 overflow-hidden rounded-sm bg-gray-800">
+                <div class="relative aspect-[9/16]">
+                    {% set image = get_image(term.meta('dossier_afbeelding_hoog')) %}
+                    {{ responsive.render(
+                        src: image.src,
+                        width: 226,
+                        height: 402,
+                        sizes: '(min-width: 960px) 226px, (min-width: 640px) calc((100vw - 3.5rem) / 4), calc((100vw - 3rem) / 3)',
+                        alt: image.alt|default(term.title),
+                        class: 'absolute inset-0 w-full',
+                    ) }}
+                    <i class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black opacity-60"></i>
+                    <h2 class="absolute inset-x-0 bottom-0 p-4 text-center text-md font-black text-white sm:text-xl">{{ term.title }}</h2>
+                </div>
+            </a>
         {% endfor %}
-    </div>
-    <div data-scroller-nav hidden>
-        <button type="button" data-scroller-prev disabled aria-label="Vorige dossiers"
-                class="group absolute inset-y-0 left-0 hidden w-(--grid-inset) bg-white/50 transition hover:bg-white/70 disabled:cursor-default dark:bg-gray-800/50 dark:hover:bg-gray-800/70 [@media(pointer:fine)]:block">
-            <span class="absolute top-1/2 right-0 flex h-16 w-16 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white text-gray-800 shadow-lg">{{ icon('icon-arrow_back') }}</span>
-        </button>
-        <button type="button" data-scroller-next aria-label="Volgende dossiers"
-                class="group absolute inset-y-0 right-0 hidden w-(--grid-inset) bg-white/50 transition hover:bg-white/70 disabled:cursor-default dark:bg-gray-800/50 dark:hover:bg-gray-800/70 [@media(pointer:fine)]:block">
-            <span class="absolute top-1/2 left-0 flex h-16 w-16 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white text-gray-800 shadow-lg">{{ icon('icon-arrow_forward') }}</span>
-        </button>
-    </div>
-</section>
+    {% endblock %}
+{% endembed %}

--- a/templates/partial/carousel.twig
+++ b/templates/partial/carousel.twig
@@ -1,0 +1,36 @@
+{#
+ # Shared horizontal carousel shell.
+ #
+ # Required context: id, title, previous_label, next_label.
+ # Optional context: root_class, root_style, header_class, title_class, track_class, track_tag.
+ # Blocks: items, footer.
+ #}
+{% set title_id = id ~ '-title' %}
+{% set track_id = id ~ '-track' %}
+{% set track_tag = track_tag|default('div') %}
+{% set button_class = 'flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 text-white transition hover:bg-gray-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-roze disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500' %}
+
+<section class="{{ root_class|default('') }}" data-scroller aria-labelledby="{{ title_id }}"
+         {% if root_style|default(null) %}style="{{ root_style }}"{% endif %}>
+    <div class="mx-auto mb-5 flex w-full max-w-960 flex-wrap items-center gap-x-4 gap-y-1 px-4 {{ header_class|default('') }}">
+        <h2 id="{{ title_id }}" class="text-3xl font-bold {{ title_class|default('') }}">{{ title }}</h2>
+        <div class="ml-auto flex items-center gap-1.5" data-scroller-nav hidden>
+            <button type="button" class="{{ button_class }}" data-scroller-prev disabled
+                    aria-controls="{{ track_id }}" aria-label="{{ previous_label }}">
+                <span aria-hidden="true">{{ icon('icon-arrow_back') }}</span>
+            </button>
+            <button type="button" class="{{ button_class }}" data-scroller-next
+                    aria-controls="{{ track_id }}" aria-label="{{ next_label }}">
+                <span aria-hidden="true">{{ icon('icon-arrow_forward') }}</span>
+            </button>
+        </div>
+    </div>
+
+    <{{ track_tag }} id="{{ track_id }}"
+        class="flex snap-x snap-proximity overflow-x-auto scrollbar-none *:flex-none *:snap-start {{ track_class|default('') }}"
+        data-scroller-track aria-labelledby="{{ title_id }}">
+        {% block items %}{% endblock %}
+    </{{ track_tag }}>
+
+    {% block footer %}{% endblock %}
+</section>

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -131,44 +131,43 @@
         </div>
 
         {% if gemist.days is not empty %}
-            <section class="bg-gray-800 text-white dark:border-t dark:border-gray-700/50" data-scroller>
-                <div class="mx-auto w-full max-w-960 px-4 py-8">
-                    <div class="mb-5 flex flex-wrap items-center gap-x-4 gap-y-1">
-                        <h2 class="text-3xl font-bold">Uitzending gemist</h2>
-                        <div class="ml-auto flex items-center gap-1.5" data-scroller-nav hidden>
-                            <button type="button" data-scroller-prev disabled aria-label="Nieuwere uitzendingen"
-                                    class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">{{ icon('icon-arrow_back') }}</button>
-                            <button type="button" data-scroller-next aria-label="Oudere uitzendingen"
-                                    class="flex h-8 w-8 items-center justify-center rounded-sm bg-gray-700 transition hover:bg-gray-600 disabled:cursor-default disabled:bg-gray-700/40 disabled:text-gray-500">{{ icon('icon-arrow_forward') }}</button>
-                        </div>
-                    </div>
-
-                    <ul class="-mx-4 flex snap-x snap-proximity gap-3 overflow-x-auto scrollbar-none px-4 py-1 scroll-px-4 sm:gap-4"
-                        data-scroller-track>
-                        {% for day in gemist.days %}
-                            <li class="w-28 flex-none snap-start rounded-sm bg-gray-700/50 p-3 text-center sm:w-44 sm:p-4">
-                                <span class="block font-round text-xs font-bold tracking-wide text-gray-400 uppercase">
-                                    <span class="sm:hidden">{{ day.date.locale('nl').isoFormat('dd') }}</span>
-                                    <span class="hidden sm:inline">{{ day.date.locale('nl').isoFormat('dddd') }}</span>
-                                </span>
-                                <span class="mb-3.5 block text-sm font-semibold">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
-                                <div class="flex flex-col gap-2">
-                                    {% for time in day.times %}
-                                        <a class="rounded-sm bg-gray-700 px-3 py-2 text-center text-xs font-bold text-white transition hover:bg-gray-600"
-                                           href="{{ options.radio_gemist_baseurl|replace({'<date>': time.format(options.radio_gemist_file)}) }}"
-                                           target="_blank" rel="noopener">{{ time.locale('nl').isoFormat('HH:mm') }}</a>
-                                    {% endfor %}
-                                </div>
-                            </li>
-                        {% endfor %}
-                    </ul>
-
-                    {% if gemist.retention_label %}
-                        <p class="mt-4 text-sm text-gray-400">Je kunt uitzendingen tot {{ gemist.retention_label }} terugluisteren.</p>
+            {% embed 'partial/carousel.twig' with {
+                id: 'fm-recordings',
+                title: 'Uitzending gemist',
+                previous_label: 'Nieuwere uitzendingen',
+                next_label: 'Oudere uitzendingen',
+                root_class: 'bg-gray-800 py-8 text-white dark:border-t dark:border-gray-700/50',
+                track_tag: 'ul',
+                track_class: 'mx-auto w-full max-w-960 gap-3 px-4 py-1 scroll-px-4 sm:gap-4',
+                days: gemist.days,
+                retention_label: gemist.retention_label,
+                recording_base_url: options.radio_gemist_baseurl,
+                recording_file: options.radio_gemist_file,
+            } %}
+                {% block items %}
+                    {% for day in days %}
+                        <li class="w-28 rounded-sm bg-gray-700/50 p-3 text-center sm:w-44 sm:p-4">
+                            <span class="block font-round text-xs font-bold tracking-wide text-gray-400 uppercase">
+                                <span class="sm:hidden">{{ day.date.locale('nl').isoFormat('dd') }}</span>
+                                <span class="hidden sm:inline">{{ day.date.locale('nl').isoFormat('dddd') }}</span>
+                            </span>
+                            <span class="mb-3.5 block text-sm font-semibold">{{ day.date.locale('nl').isoFormat('D MMMM') }}</span>
+                            <div class="flex flex-col gap-2">
+                                {% for time in day.times %}
+                                    <a class="rounded-sm bg-gray-700 px-3 py-2 text-center text-xs font-bold text-white transition hover:bg-gray-600"
+                                       href="{{ recording_base_url|replace({'<date>': time.format(recording_file)}) }}"
+                                       target="_blank" rel="noopener">{{ time.locale('nl').isoFormat('HH:mm') }}</a>
+                                {% endfor %}
+                            </div>
+                        </li>
+                    {% endfor %}
+                {% endblock %}
+                {% block footer %}
+                    {% if retention_label %}
+                        <p class="mx-auto mt-4 w-full max-w-960 px-4 text-sm text-gray-400">Je kunt uitzendingen tot {{ retention_label }} terugluisteren.</p>
                     {% endif %}
-
-                </div>
-            </section>
+                {% endblock %}
+            {% endembed %}
         {% endif %}
     </article>
 {% endblock %}


### PR DESCRIPTION
## Samenvatting

- voegt een gedeelde, composeerbare Twig-shell toe voor horizontale carrousels
- migreert zowel de dossiercarrousel op de voorpagina als Uitzending gemist
- laat de voorpagina de compacte FM-pijlen, focus-styling en headerindeling overnemen
- centraliseert scroll-, snap- en ARIA-attributen zonder domeinspecifieke kaartmarkup in het component te stoppen

## Zichtbare impact

De grote zwevende dossierpijlen maken plaats voor dezelfde compacte knoppen naast de titel die FM Gemist gebruikt. De dossierkaarten en FM-opnames behouden hun eigen formaat en inhoud.

## Verificatie

- `vendor/bin/phpcs --standard=phpcs.xml .`
- `composer lint:twig`
- `npm run build:tailwind`
- `node --check static/site.js`
- strikte Twig-renderchecks voor beide carrouselvarianten
- `git diff --check`

## Screenshots

Niet toegevoegd: in deze checkout draait geen gevulde lokale WordPress-contentomgeving. De visuele wijziging is beperkt tot de dossiernavigatie zoals hierboven beschreven.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized carousel layouts across dossier and missed-broadcast sections.
  * Improved consistency of carousel navigation, scrolling, and responsive presentation.
  * Preserved existing content, links, images, recording access, and retention information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->