### PR TITLE
chore: require WordPress 7.0 and PHP 8.3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,14 +14,14 @@ This is a WordPress theme with some hard dependencies. You can't run it without 
 ## Hard dependencies
 Install these before activating the theme:
 - Timber 2.5.1: Bundled via Composer, no separate installation needed
-- Secure Custom Fields 6.8.x or Advanced Custom Fields Pro 6.x: Docker uses [Secure Custom Fields](https://wordpress.org/plugins/secure-custom-fields/) for development; licensed environments may use [ACF Pro](https://www.advancedcustomfields.com/pro/).
-- Classic Editor 1.x: [[free download](https://wordpress.org/plugins/classic-editor/)] _(we are giving the block editor more time to stabilize)_
-- Yoast SEO Premium 27.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]
+- Secure Custom Fields 6.9+ or Advanced Custom Fields Pro 6.8+: Docker uses [Secure Custom Fields](https://wordpress.org/plugins/secure-custom-fields/) for development; licensed environments may use [ACF Pro](https://www.advancedcustomfields.com/pro/).
+- Yoast SEO 27.7+ (free or Premium): [free download](https://wordpress.org/plugins/wordpress-seo/) or [purchase Premium](https://yoast.com/wordpress/plugins/seo/)
 
 ## Soft dependencies
-These are tested plugins and are great additions to the theme:
-- Contact Form 7 6.0.x: [[free download](https://wordpress.org/plugins/contact-form-7/)]
-- Disable Comments 2.x: [[free download](https://wordpress.org/plugins/disable-comments/)]
+These optional plugins complement the theme:
+- Classic Editor 1.7.x: [free download](https://wordpress.org/plugins/classic-editor/)
+- Contact Form 7 6.1.x: [free download](https://wordpress.org/plugins/contact-form-7/)
+- Disable Comments 2.7.x: [free download](https://wordpress.org/plugins/disable-comments/)
 
 ## REST API Endpoints
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,17 +8,22 @@ This is a WordPress theme with some hard dependencies. You can't run it without 
 4. Switch to the `streekomroep` theme
 
 ## Requirements
+
 - WordPress 7.0 or higher
 - PHP 8.3 or higher
 
 ## Hard dependencies
+
 Install these before activating the theme:
+
 - Timber 2.5.1: Bundled via Composer, no separate installation needed
 - Secure Custom Fields 6.9+ or Advanced Custom Fields Pro 6.8+: Docker uses [Secure Custom Fields](https://wordpress.org/plugins/secure-custom-fields/) for development; licensed environments may use [ACF Pro](https://www.advancedcustomfields.com/pro/).
 - Yoast SEO 27.7+ (free or Premium): [free download](https://wordpress.org/plugins/wordpress-seo/) or [purchase Premium](https://yoast.com/wordpress/plugins/seo/)
 
 ## Soft dependencies
+
 These optional plugins complement the theme:
+
 - Classic Editor 1.7.x: [free download](https://wordpress.org/plugins/classic-editor/)
 - Contact Form 7 6.1.x: [free download](https://wordpress.org/plugins/contact-form-7/)
 - Disable Comments 2.7.x: [free download](https://wordpress.org/plugins/disable-comments/)
@@ -28,12 +33,15 @@ These optional plugins complement the theme:
 The theme provides the following REST API endpoints:
 
 ### Tekst TV
-```
+
+```text
 GET /wp-json/zw/v1/teksttv?channel={channel}
 ```
+
 Returns slides and ticker messages for the Tekst TV system. The `channel` parameter is required and must match a configured channel (e.g., `tv1`).
 
 Response format:
+
 ```json
 {
   "slides": [...],

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,13 +2,13 @@
 
 This is a WordPress theme with some hard dependencies. You can't run it without these dependencies.
 
-1. Install WordPress 6.9+
+1. Install WordPress 7.0+
 2. Install and activate the hard dependencies
 3. Upload the theme to your `wp-content/themes`
 4. Switch to the `streekomroep` theme
 
 ## Requirements
-- WordPress 6.9 or higher
+- WordPress 7.0 or higher
 - PHP 8.3 or higher
 
 ## Hard dependencies

--- a/README.md
+++ b/README.md
@@ -1,124 +1,96 @@
+# Streekomroep WordPress Theme
 
-# The Streekomroep WordPress Theme
+The WordPress theme for [Streekomroep ZuidWest](https://www.zuidwestupdate.nl/), built with [Timber](https://timber.github.io/docs/v2/), Twig, and Tailwind CSS. It supports regional news, radio, television, video, and Tekst TV.
 
-This is a WordPress theme created for Streekomroep ZuidWest in the Netherlands. It utilizes Timber and Tailwind CSS, offering functionality for regional news, radio, and TV broadcasts. Use it with WordPress 6.9+ and PHP 8.3+.
+## Requirements
 
-## How to install
-Get the latest version from the [Releases tab](https://github.com/oszuidwest/streekomroep-wp/releases) and upload it as theme to your WordPress installation. Ensure to install all the hard dependencies too.
+- WordPress 7.0+
+- PHP 8.3+
+- Secure Custom Fields 6.8.x or Advanced Custom Fields Pro 6.x
+- Classic Editor 1.x
+- Yoast SEO Premium 27.x
 
-## How to manually build
-You can also build the theme yourself.
+Timber 2.5.x and other PHP libraries are bundled through Composer. Secure Custom Fields (or ACF Pro) and Yoast SEO must be active before activating the theme.
 
-Instructions for macOS:
-- Install Homebrew ([https://brew.sh](https://brew.sh))
-- Install Composer and Node with `brew install composer node`
-- Download the theme from GitHub to a local folder
-- Open the folder in a terminal and execute the following commands:
+## Installation
+
+For production, download the latest archive from [GitHub Releases](https://github.com/oszuidwest/streekomroep-wp/releases), install the required plugins, and upload the theme through WordPress or extract it to `wp-content/themes/streekomroep`. Release archives include Composer dependencies and compiled CSS.
+
+To build the theme from source:
 
 ```bash
+composer install --prefer-dist --no-dev --optimize-autoloader
 npm install
 npm run build:tailwind
-composer install --prefer-dist --no-dev --optimize-autoloader
 ```
-- Upload the theme to `/wp-content/themes/` and activate it.
 
-For Linux users, use `apt` or `yum` instead of Homebrew. This theme has not been tested on Windows, but should work if your Composer and Node versions are up-to-date. To build remotely, consider using GitHub Actions or [Buddy CI/CD](https://buddy.works/) for the building and uploading process.
+## Development
 
-## Local development with Docker
-A Docker setup is included for local development. It provides WordPress on PHP 8.3 with the theme mounted, MariaDB LTS, phpMyAdmin, and Secure Custom Fields for development.
+The Docker environment provides WordPress 7.0 on PHP 8.3, MariaDB, phpMyAdmin, WP-CLI, and the required development plugins.
 
 ```bash
 docker compose up -d
 ```
 
-This starts:
-- WordPress at http://localhost:8080 (admin/admin)
-- phpMyAdmin at http://localhost:8081
+On first startup it installs WordPress, builds the theme, creates the default menus, and activates the theme.
 
-The theme folder is mounted into the container, so changes are reflected immediately. On first run, WordPress is automatically installed with Dutch locale and the theme activated.
+- WordPress: <http://localhost:8080> (`admin` / `admin`)
+- phpMyAdmin: <http://localhost:8081> (`wordpress` / `wordpress`)
 
-To stop: `docker compose down`
-To reset: `docker compose down -v` (removes database)
+Stop the environment with `docker compose down`. To delete the local database and start over, use `docker compose down -v`.
 
-After changing the WordPress image version, reset the disposable development
-environment and rebuild it: `docker compose down -v && docker compose up -d --build`.
+For development without the automatic Docker build:
 
-### Hard dependencies
-Install these before activating the theme:
-- Timber 2.5.1: [Bundled; if you build yourself, use composer](https://timber.github.io/docs/v2/installation/installation/)
-- Secure Custom Fields 6.8.x or Advanced Custom Fields Pro 6.x: Docker uses [Secure Custom Fields](https://wordpress.org/plugins/secure-custom-fields/) for development; licensed environments may use [ACF Pro](https://www.advancedcustomfields.com/pro/).
-- Classic Editor 1.x: [[free download](https://wordpress.org/plugins/classic-editor/)] _(we are giving the block editor more time to stabilize)_
-- Yoast SEO Premium 27.x: [[purchase](https://yoast.com/wordpress/plugins/seo/)]
-
-### Soft dependencies
-These tested plugins enhance the theme:
-- Contact Form 7 6.0.x: [[free download](https://wordpress.org/plugins/contact-form-7/)]
-- Disable Comments 2.x: [[free download](https://wordpress.org/plugins/disable-comments/)]
-
-## Extra functionality with first-party plugins
-Some first-party plugins developed by Streekomroep ZuidWest add extra functionality to this theme. They are optional and can be installed separately:
-- ZuidWest Webapp [[on GitHub](https://github.com/oszuidwest/zw-webapp)]: Adds push messages and functionality for a progressive web app using the service Progressier.
-- Tekst TV GPT [[on GitHub](https://github.com/oszuidwest/teksttvgpt)]: Adds a button that generates 'tekst tv' summaries for articles using OpenAI GPT models.
-
-## Optional: imgproxy for image resizing
-
-The theme supports [imgproxy](https://imgproxy.net/) for on-the-fly image resizing with signed URLs. When configured, all images rendered with the `|imgproxy` Twig filter are served through imgproxy. Without it, the theme falls back to Timber's built-in image resizing.
-
-Configure imgproxy in WordPress under Settings > Media:
-
-- `zw_imgproxy_key`
-- `zw_imgproxy_salt`
-- `zw_imgproxy_url`
-
-The `zw_imgproxy_url` value is normalized (`https://` is added when no scheme is entered, and a trailing slash is enforced). Normalization runs both when saving the option and when reading the constant fallback, so the constants below also work without a trailing slash. Empty WordPress options are backfilled from the matching constants in wp-admin. Invalid URLs are rejected with an admin notice.
-
-For deployments that still define these values in `wp-config.php`, the following constants are still supported as a per-key fallback when the matching option is empty:
-
-```php
-define('IMGPROXY_KEY', 'your-hex-key');
-define('IMGPROXY_SALT', 'your-hex-salt');
-define('IMGPROXY_URL', 'https://your-imgproxy-instance.example.com/');
+```bash
+composer install
+npm install
+npm run watch:tailwind
 ```
 
-## REST API Endpoints
+Run `npm run build:tailwind` to compile minified CSS from `assets/` into `dist/`.
 
-The theme provides REST API endpoints for external integrations:
+### Quality checks
 
-### Broadcast Data
-```
-GET /wp-json/zw/v1/broadcast_data
-```
-Returns the current and next radio broadcast, plus today's and tomorrow's TV schedule.
+There is no dedicated automated test suite. Run the PHP and Twig linters before submitting changes:
 
-Response:
-```json
-{
-  "fm": {
-    "now": "Program Name",
-    "next": "Program Name"
-  },
-  "tv": {
-    "today": ["Show 1", "Show 2"],
-    "tomorrow": ["Show 1", "Show 2"]
-  }
-}
+```bash
+vendor/bin/phpcs --standard=phpcs.xml .
+composer lint:twig
 ```
 
-### Tekst TV
-```
-GET /wp-json/zw/v1/teksttv?channel={channel}
-```
-Returns slides and ticker messages for the [Tekst TV system](https://github.com/oszuidwest/teksttv). The `channel` parameter must match a configured channel (e.g., `tv1`).
+Use `composer fix:twig` to fix supported Twig formatting issues. Verify frontend changes in Docker and rebuild the CSS.
 
-Response:
-```json
-{
-  "slides": [...],
-  "ticker": [...]
-}
-```
+## Project structure
 
-## What's here?
-`static/`: Store your static front-end scripts, styles, or images here, including Sass files, JS files, fonts, and SVGs.
+| Path | Purpose |
+| --- | --- |
+| `src/` | PSR-4 classes in the `Streekomroep\` namespace |
+| `lib/` | WordPress hooks, post types, taxonomies, and integrations |
+| `templates/` | Twig views |
+| `assets/` / `dist/` | Tailwind sources and generated CSS |
+| `static/` | Browser-side JavaScript |
+| `streekomroep-acf-json/` | Version-controlled SCF/ACF field groups |
+| `docker/` | Local WordPress environment |
 
-`templates/`: Contains all Twig templates, corresponding closely with the PHP files in the WordPress template hierarchy. Each PHP template ends with a `Timber::render()` function, linking to the Twig file where the data (or `$context`) is used.
+WordPress template entrypoints live in the repository root and render views from `templates/`. Commit updated JSON in `streekomroep-acf-json/` whenever SCF or ACF fields change.
+
+## Integrations
+
+### imgproxy
+
+Optional [imgproxy](https://imgproxy.net/) support can be configured under **Settings > Media** with `zw_imgproxy_key`, `zw_imgproxy_salt`, and `zw_imgproxy_url`. If any value is missing, the theme falls back to Timber image resizing.
+
+Existing deployments can use the `IMGPROXY_KEY`, `IMGPROXY_SALT`, and `IMGPROXY_URL` constants in `wp-config.php` as fallbacks.
+
+### REST API
+
+The theme provides two public read-only endpoints:
+
+- `GET /wp-json/zw/v1/broadcast_data` returns the current and next radio programme and the television schedules for today and tomorrow.
+- `GET /wp-json/zw/v1/teksttv?channel=tv1` returns slides and ticker messages for a channel configured in `ZW_TEKSTTV_CHANNELS`.
+
+Optional first-party extensions include [ZuidWest Webapp](https://github.com/oszuidwest/zw-webapp) for push notifications and PWA support, and [Tekst TV GPT](https://github.com/oszuidwest/teksttvgpt) for AI-generated Tekst TV summaries.
+
+## License
+
+See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ Use `composer fix:twig` to fix supported Twig formatting issues. Verify frontend
 
 WordPress template entrypoints live in the repository root and render views from `templates/`. Commit updated JSON in `streekomroep-acf-json/` whenever SCF or ACF fields change.
 
+## Soft dependencies
+
+These optional plugins complement the theme:
+
+- [Contact Form 7](https://wordpress.org/plugins/contact-form-7/) 6.1.x
+- [Disable Comments](https://wordpress.org/plugins/disable-comments/) 2.7.x
+
+## Extra functionality with first-party plugins
+
+- [ZuidWest Webapp](https://github.com/oszuidwest/zw-webapp) adds push notifications and PWA support.
+- [Tekst TV GPT](https://github.com/oszuidwest/teksttvgpt) adds AI-generated Tekst TV summaries to the editor.
+
 ## Integrations
 
 ### imgproxy
@@ -88,8 +100,6 @@ The theme provides two public read-only endpoints:
 
 - `GET /wp-json/zw/v1/broadcast_data` returns the current and next radio programme and the television schedules for today and tomorrow.
 - `GET /wp-json/zw/v1/teksttv?channel=tv1` returns slides and ticker messages for a channel configured in `ZW_TEKSTTV_CHANNELS`.
-
-Optional first-party extensions include [ZuidWest Webapp](https://github.com/oszuidwest/zw-webapp) for push notifications and PWA support, and [Tekst TV GPT](https://github.com/oszuidwest/teksttvgpt) for AI-generated Tekst TV summaries.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ The WordPress theme for [Streekomroep ZuidWest](https://www.zuidwestupdate.nl/),
 
 - WordPress 7.0+
 - PHP 8.3+
-- Secure Custom Fields 6.8.x or Advanced Custom Fields Pro 6.x
-- Classic Editor 1.x
-- Yoast SEO Premium 27.x
+- Secure Custom Fields 6.9+ or Advanced Custom Fields Pro 6.8+
+- Yoast SEO 27.7+ (free or Premium)
 
-Timber 2.5.x and other PHP libraries are bundled through Composer. Secure Custom Fields (or ACF Pro) and Yoast SEO must be active before activating the theme.
+Timber 2.5.x and other PHP libraries are bundled through Composer. An ACF-compatible plugin and Yoast SEO must be active before activating the theme.
 
 ## Installation
 
@@ -78,6 +77,7 @@ WordPress template entrypoints live in the repository root and render views from
 
 These optional plugins complement the theme:
 
+- [Classic Editor](https://wordpress.org/plugins/classic-editor/) 1.7.x
 - [Contact Form 7](https://wordpress.org/plugins/contact-form-7/) 6.1.x
 - [Disable Comments](https://wordpress.org/plugins/disable-comments/) 2.7.x
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ Run `npm run build:tailwind` to compile minified CSS from `assets/` into `dist/`
 
 ### Quality checks
 
-There is no dedicated automated test suite. Run the PHP and Twig linters before submitting changes:
+There is no dedicated automated test suite. Run the baseline checks before submitting changes:
 
 ```bash
 vendor/bin/phpcs --standard=phpcs.xml .
 composer lint:twig
+git diff --check
 ```
 
 Use `composer fix:twig` to fix supported Twig formatting issues. Verify frontend changes in Docker and rebuild the CSS.

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
       "dealerdirect/phpcodesniffer-composer-installer": true
     },
     "platform": {
-      "php": "8.2"
+      "php": "8.3"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "oszuidwest/streekomroep",
   "description": "Streekomroep theme to use with Timber",
+  "license": "MPL-2.0",
   "type": "wordpress-theme",
   "minimum-stability": "stable",
   "authors": [
@@ -28,9 +29,10 @@
     "ext-dom": "*",
     "ext-fileinfo": "*",
     "ext-json": "*",
+    "php": ">=8.3",
     "league/commonmark": "^2.4",
     "nesbot/carbon": "^3.11",
-    "symfony/yaml": "^5.4",
+    "symfony/yaml": "^7.4",
     "timber/timber": "~2.5.1",
     "twig/markdown-extra": "^3.7"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5148de981c4ce4be54a541ba64ebcbf1",
+    "content-hash": "071cb5b031cdee86f3da5ffe511d8075",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -1364,31 +1364,28 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.52",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "b0b27055f055f0d314c5c68ed0c10f0bbd90aee0"
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b0b27055f055f0d314c5c68ed0c10f0bbd90aee0",
-                "reference": "b0b27055f055f0d314c5c68ed0c10f0bbd90aee0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8f328665ace2370d1e10645b807ba1646dc7dcc",
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<5.3"
+                "symfony/console": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^5.3|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "symfony/console": "^6.4|^7.0|^8.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -1419,7 +1416,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.52"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -1439,7 +1436,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-15T06:40:16+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "timber/timber",
@@ -3127,7 +3124,8 @@
     "platform": {
         "ext-dom": "*",
         "ext-fileinfo": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "php": ">=8.3"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8670c5f3371ac090b3a7debe11e214e3",
+    "content-hash": "5148de981c4ce4be54a541ba64ebcbf1",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -3131,7 +3131,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.3"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -56,7 +56,7 @@ set -e
             --allow-root
 
         # Install plugins before language pack to avoid WP-CLI locale conflicts
-        YOAST_SEO_VERSION="27.6"
+        YOAST_SEO_VERSION="27.7"
         echo "Installing Yoast SEO ${YOAST_SEO_VERSION}..."
         wp plugin install wordpress-seo --version="$YOAST_SEO_VERSION" --activate --allow-root || echo "Failed to install Yoast SEO"
 

--- a/lib/teksttv.php
+++ b/lib/teksttv.php
@@ -12,7 +12,7 @@ use WP_REST_Response;
 class TekstTVAPI
 {
     // Slide durations in milliseconds
-    private const SLIDE_DURATIONS = [
+    private const array SLIDE_DURATIONS = [
         'text' => 20000,
         'image' => 7000,
         'ad_transition' => 5000,
@@ -20,7 +20,7 @@ class TekstTVAPI
     ];
 
     // Cache duration for weather data (1 hour)
-    private const WEATHER_CACHE_DURATION = 3600;
+    private const int WEATHER_CACHE_DURATION = 3600;
 
     // Broadcast schedule shared by all ticker items in a request (building one is expensive)
     private ?BroadcastSchedule $schedule = null;
@@ -525,7 +525,11 @@ class TekstTVAPI
         }
 
         $body = wp_remote_retrieve_body($response);
-        $data = json_decode($body, true);
+        try {
+            $data = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new \Exception('Weather API returned invalid JSON', previous: $exception);
+        }
 
         if (!$data || !isset($data['daily'])) {
             throw new \Exception('Invalid API response');
@@ -563,7 +567,11 @@ class TekstTVAPI
         }
 
         $body = wp_remote_retrieve_body($response);
-        $data = json_decode($body, true);
+        try {
+            $data = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            return null;
+        }
 
         if (empty($data) || !isset($data[0]['lat'])) {
             return null;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <ruleset>
+    <config name="testVersion" value="8.3-"/>
+
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
 

--- a/src/BroadcastDay.php
+++ b/src/BroadcastDay.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 
 class BroadcastDay
 {
-    public const WEEKDAY_NAMES = [
+    public const array WEEKDAY_NAMES = [
         1 => 'maandag',
         2 => 'dinsdag',
         3 => 'woensdag',

--- a/src/BunnyClient.php
+++ b/src/BunnyClient.php
@@ -11,7 +11,7 @@ class BunnyClient
 
     private static array $credentialsCache = [];
 
-    private const LIBRARY_FIELDS = [
+    private const array LIBRARY_FIELDS = [
         'tv' => ['bunny_cdn_library_id', 'bunny_cdn_hostname', 'bunny_cdn_api_key'],
         'fragmenten' => ['bunny_cdn_library_id_fragmenten', 'bunny_cdn_hostname_fragmenten', 'bunny_cdn_api_key_fragmenten'],
     ];
@@ -70,7 +70,14 @@ class BunnyClient
             return null;
         }
 
-        return json_decode($response['body']);
+        try {
+            $video = json_decode($response['body'], flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            error_log('Invalid JSON returned by the Bunny API: ' . $exception->getMessage());
+            return null;
+        }
+
+        return is_object($video) ? $video : null;
     }
 
     public function fetchCollection(string $collectionId): array
@@ -94,7 +101,15 @@ class BunnyClient
                 throw new Exception('Error while fetching bunny data: ' . $response['body']);
             }
 
-            $body = json_decode($response['body']);
+            try {
+                $body = json_decode($response['body'], flags: JSON_THROW_ON_ERROR);
+            } catch (\JsonException $exception) {
+                throw new Exception('Invalid JSON returned by the Bunny API', previous: $exception);
+            }
+
+            if (!is_object($body) || !isset($body->items, $body->totalItems) || !is_array($body->items)) {
+                throw new Exception('Invalid data returned by the Bunny API');
+            }
 
             array_push($data, ...$body->items);
             if (count($data) >= $body->totalItems) {

--- a/src/BunnyCredentials.php
+++ b/src/BunnyCredentials.php
@@ -2,19 +2,12 @@
 
 namespace Streekomroep;
 
-class BunnyCredentials
+final readonly class BunnyCredentials
 {
-    public int $libraryId;
-    public string $hostname;
-    public string $apiKey;
-
     public function __construct(
-        int $libraryId,
-        string $hostname,
-        string $apiKey
+        public int $libraryId,
+        public string $hostname,
+        public string $apiKey
     ) {
-        $this->libraryId = $libraryId;
-        $this->hostname = $hostname;
-        $this->apiKey = $apiKey;
     }
 }

--- a/src/BunnyVideoId.php
+++ b/src/BunnyVideoId.php
@@ -2,16 +2,11 @@
 
 namespace Streekomroep;
 
-class BunnyVideoId
+final readonly class BunnyVideoId
 {
-    public int $libraryId;
-    public string $videoId;
-
     public function __construct(
-        int $libraryId,
-        string $videoId
+        public int $libraryId,
+        public string $videoId
     ) {
-        $this->videoId = $videoId;
-        $this->libraryId = $libraryId;
     }
 }

--- a/src/Fragment.php
+++ b/src/Fragment.php
@@ -6,8 +6,8 @@ use Timber\Timber;
 
 class Fragment extends Post
 {
-    public const TYPE_VIDEO = 'Video';
-    public const TYPE_AUDIO = 'Audio';
+    public const string TYPE_VIDEO = 'Video';
+    public const string TYPE_AUDIO = 'Audio';
 
     public function getEmbed(?string $posterUrl = null)
     {

--- a/src/Gallery.php
+++ b/src/Gallery.php
@@ -8,37 +8,37 @@ use WP_Post;
 
 class Gallery
 {
-    private const DEFAULT_TYPE = 'rectangular';
-    private const DEFAULT_COLUMNS = 3;
-    private const DEFAULT_IMAGE_SIZE = 'large';
-    private const MAX_COLUMNS = 6;
+    private const string DEFAULT_TYPE = 'rectangular';
+    private const int DEFAULT_COLUMNS = 3;
+    private const string DEFAULT_IMAGE_SIZE = 'large';
+    private const int MAX_COLUMNS = 6;
 
     // Galleries render inside the max-w-3xl content column, so image widths cap at 768px.
-    private const CONTENT_WIDTH = 768;
+    private const int CONTENT_WIDTH = 768;
 
     // Shared classes for every gallery tile wrapper.
-    private const ITEM_BASE = 'group relative m-0 overflow-hidden bg-gray-100';
+    private const string ITEM_BASE = 'group relative m-0 overflow-hidden bg-gray-100';
 
     // The distinct rectangular slots. Each geometry (classes/sizes/width/height) lives in exactly one place.
-    private const LAYOUT_HERO = [
+    private const array LAYOUT_HERO = [
         'classes' => self::ITEM_BASE . ' col-span-2 aspect-[16/9] md:col-span-6',
         'sizes' => '(min-width: 768px) 768px, 100vw',
         'width' => 768,
         'height' => 432,
     ];
-    private const LAYOUT_HALF = [
+    private const array LAYOUT_HALF = [
         'classes' => self::ITEM_BASE . ' aspect-[4/3] md:col-span-3',
         'sizes' => '(min-width: 768px) 384px, 50vw',
         'width' => 384,
         'height' => 288,
     ];
-    private const LAYOUT_HERO_HALF = [
+    private const array LAYOUT_HERO_HALF = [
         'classes' => self::ITEM_BASE . ' col-span-2 aspect-[16/9] md:col-span-3 md:aspect-[4/3]',
         'sizes' => '(min-width: 768px) 384px, 100vw',
         'width' => 768,
         'height' => 432,
     ];
-    private const LAYOUT_THIRD = [
+    private const array LAYOUT_THIRD = [
         'classes' => self::ITEM_BASE . ' aspect-[4/3] md:col-span-2',
         'sizes' => '(min-width: 768px) 256px, 50vw',
         'width' => 256,

--- a/src/Video.php
+++ b/src/Video.php
@@ -7,7 +7,7 @@ use Exception;
 
 class Video
 {
-    public const STATUS_FINISHED = 4;
+    public const int STATUS_FINISHED = 4;
 
     private object $data;
     private string $description = '';

--- a/src/VideoModifiedTimePresenter.php
+++ b/src/VideoModifiedTimePresenter.php
@@ -15,6 +15,7 @@ class VideoModifiedTimePresenter extends Abstract_Indexable_Tag_Presenter
 
     protected $tag_format = '<meta property="article:modified_time" content="%s" />';
 
+    #[\Override]
     public function get()
     {
         return $this->helpers->date->format($this->date);

--- a/src/VideoObject.php
+++ b/src/VideoObject.php
@@ -11,6 +11,7 @@ class VideoObject extends \Yoast\WP\SEO\Generators\Schema\Abstract_Schema_Piece
         $this->video = $video;
     }
 
+    #[\Override]
     public function generate()
     {
         $timespan = $this->video->duration;
@@ -37,6 +38,7 @@ class VideoObject extends \Yoast\WP\SEO\Generators\Schema\Abstract_Schema_Piece
         ];
     }
 
+    #[\Override]
     public function is_needed()
     {
         return true;

--- a/src/VideoSeo.php
+++ b/src/VideoSeo.php
@@ -7,8 +7,8 @@ namespace Streekomroep;
  */
 class VideoSeo
 {
-    public const OG_IMAGE_WIDTH = 1920;
-    public const OG_IMAGE_HEIGHT = 1080;
+    public const int OG_IMAGE_WIDTH = 1920;
+    public const int OG_IMAGE_HEIGHT = 1080;
     public static function register(): void
     {
         add_filter('wpseo_schema_graph_pieces', [self::class, 'addFragmentSchema'], 11, 2);

--- a/style.css
+++ b/style.css
@@ -2,5 +2,6 @@
  * Theme Name: Streekomroep
  * Description: This is a WordPress theme made for Streekomroep ZuidWest in the Netherlands. It's made using Timber and Tailwind CSS and provides functionality for regional news, radio and television broadcasts.
  * Author: Streekomroep ZuidWest
+ * Requires at least: 7.0
  * Version: 1.16.3
 */

--- a/style.css
+++ b/style.css
@@ -3,5 +3,6 @@
  * Description: This is a WordPress theme made for Streekomroep ZuidWest in the Netherlands. It's made using Timber and Tailwind CSS and provides functionality for regional news, radio and television broadcasts.
  * Author: Streekomroep ZuidWest
  * Requires at least: 7.0
+ * Requires PHP: 8.3
  * Version: 1.16.3
 */


### PR DESCRIPTION
## Summary

- Require WordPress 7.0 and PHP 8.3 in theme, Composer, Docker, and docs.
- Refresh plugin requirements and update Symfony YAML to 7.4 and Yoast to 27.7.
- Use PHP 8.3 type safety and explicit JSON error handling.
- Replace the old README while retaining optional and first-party plugin guidance.

## Checks

- Composer validate, audit, install, and direct-dependency check
- PHPCS and PHP syntax checks
- Twig lint
- npm audit and Tailwind build
- Docker entrypoint syntax and `git diff --check`