### PR TITLE
fix: restore override-only TV schedule entries

### DIFF
--- a/src/BroadcastSchedule.php
+++ b/src/BroadcastSchedule.php
@@ -52,21 +52,21 @@ class BroadcastSchedule
                 $dayname = $day->getName();
 
                 foreach (zw_acf_rows($week['tv_week_shows'] ?? null) as $entry) {
-                    if (
-                        ($entry['dag'] ?? null) !== $dayname
-                        || !(($entry['show'] ?? null) instanceof \WP_Post)
-                    ) {
+                    if (($entry['dag'] ?? null) !== $dayname) {
                         continue;
                     }
 
-                    $show = Timber::get_post($entry['show']->ID);
-                    if (!$show) {
+                    $name = is_string($entry['naam_override'] ?? null) ? trim($entry['naam_override']) : '';
+                    $show = ($entry['show'] ?? null) instanceof \WP_Post ? Timber::get_post($entry['show']->ID) : null;
+
+                    // Override-only rows are valid for generic schedule entries such as reruns.
+                    if (!$show && $name === '') {
                         continue;
                     }
 
                     $day->addTelevision(new TelevisionBroadcast(
                         $show,
-                        is_string($entry['naam_override'] ?? null) ? $entry['naam_override'] : '',
+                        $name,
                         is_string($entry['starttijden'] ?? null) ? $entry['starttijden'] : ''
                     ));
                 }


### PR DESCRIPTION
## Summary

- restore TV schedule rows that use a name override without a linked TV show
- continue ignoring rows that have neither a valid show nor a usable override
- fixes the empty “Vandaag op ZuidWest TV” block for Saturday rerun schedules

## Testing

- `vendor/bin/phpcs --standard=phpcs.xml .`
- `composer lint:twig`
- verified the selection logic read-only against the current production schedule; Saturday returns “Herhalingen afgelopen week”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved television schedule handling for entries with custom names but no linked show.
  * Schedule rows are now normalized more consistently, including trimmed custom names.
  * Invalid show references no longer prevent valid schedule entries from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->