### PR TITLE
chore: bump theme version to 1.17.1

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,5 +4,5 @@
  * Author: Streekomroep ZuidWest
  * Requires at least: 7.0
  * Requires PHP: 8.3
- * Version: 1.17.0
+ * Version: 1.17.1
  */


### PR DESCRIPTION
## Summary

- bump the WordPress theme version from 1.17.0 to 1.17.1
- prepare a patch release containing the TV schedule regression fix from #210

## Testing

- `vendor/bin/phpcs --standard=phpcs.xml .`
- `composer lint:twig`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WordPress theme version to 1.17.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->