### PR TITLE
feat: add opt-in stream diagnostics panel to FM live page

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -968,6 +968,21 @@ function zw_enqueue_theme_assets()
 
 add_action('wp_enqueue_scripts', 'zw_enqueue_theme_assets');
 
+/**
+ * Whether the FM stream diagnostics panel was requested.
+ *
+ * Gated on a query parameter rather than a capability so a listener reporting a playback
+ * problem can be handed a working link without an account. The panel only reports what the
+ * browser already exposes to any script on the page, so it discloses nothing extra.
+ */
+function zw_fm_stream_diagnostics_enabled()
+{
+    // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only display toggle.
+    $debug = isset($_GET['debug']) ? sanitize_key(wp_unslash($_GET['debug'])) : '';
+
+    return $debug === 'streams';
+}
+
 /** Adds VideoJS as a dependency only when the controller requested a stream player. */
 function zw_enqueue_fm_live_assets()
 {
@@ -979,6 +994,18 @@ function zw_enqueue_fm_live_assets()
         'zw-fm-live',
         get_theme_file_uri('static/fm-live.js'),
         empty($GLOBALS['zw_requires_videojs']) ? [] : ['zw-videojs-init'],
+        wp_get_theme()->get('Version'),
+        ['strategy' => 'defer', 'in_footer' => true]
+    );
+
+    if (!zw_fm_stream_diagnostics_enabled()) {
+        return;
+    }
+
+    wp_enqueue_script(
+        'zw-fm-stream-diagnostics',
+        get_theme_file_uri('static/fm-stream-diagnostics.js'),
+        [],
         wp_get_theme()->get('Version'),
         ['strategy' => 'defer', 'in_footer' => true]
     );

--- a/static/fm-stream-diagnostics.js
+++ b/static/fm-stream-diagnostics.js
@@ -1,0 +1,253 @@
+// Kept out of fm-live.js so a fault in the diagnostics path can never take the player down.
+(function () {
+    const PANEL = document.querySelector('[data-stream-diagnostics]');
+    if (!PANEL) {
+        return;
+    }
+
+    const PROBE_TIMEOUT = 10000;
+
+    const PROBES = [
+        ['MP3', 'audio/mpeg'],
+        ['AAC container (kaal)', 'audio/mp4'],
+        ['AAC-LC', 'audio/mp4; codecs="mp4a.40.2"'],
+        ['HE-AAC v1 (AAC+)', 'audio/mp4; codecs="mp4a.40.5"'],
+        ['HE-AAC v2 (eAAC+)', 'audio/mp4; codecs="mp4a.40.29"'],
+        ['Rauwe AAC (ADTS)', 'audio/aac'],
+        ['Icecast AAC+', 'audio/aacp'],
+        ['Ogg Vorbis', 'audio/ogg; codecs="vorbis"'],
+        ['Ogg Opus', 'audio/ogg; codecs="opus"'],
+        ['HLS (native)', 'application/vnd.apple.mpegurl'],
+        ['HLS (legacy MIME)', 'application/x-mpegURL']
+    ];
+
+    const MEDIA_ERRORS = {
+        1: 'MEDIA_ERR_ABORTED (afgebroken)',
+        2: 'MEDIA_ERR_NETWORK (netwerk of CORS)',
+        3: 'MEDIA_ERR_DECODE (bytes komen binnen, decoder weigert)',
+        4: 'MEDIA_ERR_SRC_NOT_SUPPORTED (bron of codec niet ondersteund)'
+    };
+
+    const OK = 'font-bold text-green-700 dark:text-green-400';
+    const BAD = 'font-bold text-red-700 dark:text-red-400';
+    const MEH = 'font-bold text-amber-700 dark:text-amber-400';
+
+    const answers = {};
+    const tester = document.createElement('audio');
+
+    function canPlay(mime) {
+        try {
+            return tester.canPlayType(mime) || '';
+        } catch (error) {
+            return '';
+        }
+    }
+
+    function supportsViaMse(mime) {
+        if (!window.MediaSource || typeof MediaSource.isTypeSupported !== 'function') {
+            return null;
+        }
+
+        try {
+            return MediaSource.isTypeSupported(mime);
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function addCell(row, text, className) {
+        const cell = document.createElement('td');
+        cell.className = `py-2 pr-3 align-top ${className || ''}`.trim();
+        cell.textContent = text;
+        row.appendChild(cell);
+        return cell;
+    }
+
+    function addCodeCell(row, text) {
+        const cell = document.createElement('td');
+        cell.className = 'py-2 pr-3 align-top';
+        const code = document.createElement('code');
+        code.className = 'text-xs break-all';
+        code.textContent = text;
+        cell.appendChild(code);
+        row.appendChild(cell);
+        return cell;
+    }
+
+    function renderCodecs() {
+        const body = PANEL.querySelector('[data-diagnostics-codecs]');
+        PROBES.forEach(function ([label, mime]) {
+            const answer = canPlay(mime);
+            answers[mime] = answer;
+
+            const mse = supportsViaMse(mime);
+            const row = document.createElement('tr');
+            row.className = 'border-b border-gray-800/5 dark:border-gray-200/5';
+
+            addCell(row, label);
+            addCodeCell(row, mime);
+            addCell(row, answer || 'nee', answer === 'probably' ? OK : (answer === 'maybe' ? MEH : BAD));
+            addCell(row, mse === null ? '-' : (mse ? 'ja' : 'nee'), mse ? OK : '');
+            body.appendChild(row);
+        });
+    }
+
+    function renderVerdict() {
+        const verdict = PANEL.querySelector('[data-diagnostics-verdict]');
+        const container = answers['audio/mp4'];
+        const heAac = answers['audio/mp4; codecs="mp4a.40.5"'] || answers['audio/mp4; codecs="mp4a.40.29"'];
+        const lines = [];
+
+        // The theme advertises its AAC stream as bare `audio/mp4`, so that is the answer the player
+        // acts on. A device that accepts the container but rejects HE-AAC will pick a stream it
+        // cannot decode, and Video.js commits to that one source instead of trying the MP3 behind it.
+        if (!container) {
+            lines.push('Deze browser wijst audio/mp4 af, dus de speler slaat de AAC-bron over en pakt MP3. Dit is niet de oorzaak.');
+        } else if (!heAac) {
+            lines.push(`Verdacht: audio/mp4 wordt geaccepteerd (${container}) maar HE-AAC wordt afgewezen. Is de stream AAC+, dan kiest de speler hem wel en kan dit toestel hem niet decoderen.`);
+        } else {
+            lines.push('Dit toestel claimt AAC-LC en HE-AAC aan te kunnen, dus de stilte komt waarschijnlijk niet door de codec.');
+        }
+
+        if (!answers['audio/mpeg']) {
+            lines.push('Waarschuwing: zelfs MP3 wordt afgewezen, wat op een uitgeklede WebView wijst.');
+        }
+
+        verdict.textContent = lines.join(' ');
+    }
+
+    function readSources() {
+        // Read the server-rendered <source> children rather than a separate data attribute, so the
+        // panel can never disagree with what the player is actually offered.
+        return Array.from(document.querySelectorAll('#zw-fm-stream source'), function (element) {
+            return {src: element.getAttribute('src') || '', type: element.getAttribute('type') || ''};
+        });
+    }
+
+    function renderSources(sources) {
+        const body = PANEL.querySelector('[data-diagnostics-sources]');
+        body.textContent = '';
+
+        if (!sources.length) {
+            const row = document.createElement('tr');
+            const cell = addCell(row, 'Geen bronnen in de pagina. Alle stream-velden in ACF zijn leeg.', MEH);
+            cell.colSpan = 4;
+            body.appendChild(row);
+            return [];
+        }
+
+        let chosen = -1;
+        return sources.map(function (source, index) {
+            const answer = canPlay(source.type);
+            const picked = chosen === -1 && answer !== '';
+            if (picked) {
+                chosen = index;
+            }
+
+            const row = document.createElement('tr');
+            row.className = 'border-b border-gray-800/5 dark:border-gray-200/5';
+            addCell(row, String(index + 1));
+
+            const srcCell = document.createElement('td');
+            srcCell.className = 'py-2 pr-3 align-top';
+            const code = document.createElement('code');
+            code.className = 'text-xs break-all';
+            code.textContent = source.src;
+            srcCell.appendChild(code);
+            srcCell.appendChild(document.createElement('br'));
+            const type = document.createElement('span');
+            type.className = 'text-xs text-gray-500 dark:text-gray-400';
+            type.textContent = `${source.type} → canPlayType: ${answer || 'nee'}`;
+            srcCell.appendChild(type);
+
+            if (location.protocol === 'https:' && source.src.indexOf('http://') === 0) {
+                srcCell.appendChild(document.createElement('br'));
+                const warning = document.createElement('strong');
+                warning.className = BAD;
+                warning.textContent = 'mixed content: https-pagina met http-stream';
+                srcCell.appendChild(warning);
+            }
+
+            row.appendChild(srcCell);
+            addCell(row, picked ? 'speler kiest deze' : (answer ? 'kan, wordt niet gekozen' : 'overgeslagen'), picked ? OK : '');
+            const result = addCell(row, 'nog niet getest', MEH);
+            body.appendChild(row);
+
+            return {source: source, result: result};
+        });
+    }
+
+    function testSource(source, cell) {
+        return new Promise(function (resolve) {
+            const element = new Audio();
+            element.muted = true;
+            element.preload = 'auto';
+
+            let settled = false;
+            const finish = function (text, className) {
+                if (settled) {
+                    return;
+                }
+
+                settled = true;
+                clearTimeout(timer);
+                cell.textContent = text;
+                cell.className = `py-2 pr-3 align-top ${className}`;
+                try {
+                    element.pause();
+                    element.removeAttribute('src');
+                    element.load();
+                } catch (error) {
+                    // The element is already torn down.
+                }
+
+                resolve();
+            };
+
+            const timer = setTimeout(function () {
+                finish('timeout, geen data en geen fout', BAD);
+            }, PROBE_TIMEOUT);
+
+            element.addEventListener('playing', () => finish('speelt af', OK));
+            element.addEventListener('canplay', () => finish('genoeg gebufferd', OK));
+            element.addEventListener('error', function () {
+                const code = element.error ? element.error.code : 0;
+                finish(MEDIA_ERRORS[code] || `onbekende fout ${code}`, BAD);
+            });
+
+            element.src = source.src;
+            element.load();
+            // A rejected play() says nothing about the codec, so keep waiting for the media events.
+            element.play()?.catch(() => {});
+        });
+    }
+
+    function renderEnv() {
+        PANEL.querySelector('[data-diagnostics-env]').textContent = [
+            `userAgent: ${navigator.userAgent}`,
+            `secure context: ${window.isSecureContext ? 'ja' : 'nee'}`,
+            `MediaSource: ${window.MediaSource ? 'aanwezig' : 'afwezig'}`,
+            `Video.js: ${typeof videojs === 'undefined' ? 'niet geladen' : videojs.VERSION}`
+        ].join(' | ');
+    }
+
+    renderCodecs();
+    renderVerdict();
+    renderEnv();
+
+    let rows = renderSources(readSources());
+
+    PANEL.querySelector('[data-diagnostics-run]').addEventListener('click', async function (event) {
+        const button = event.currentTarget;
+        button.disabled = true;
+        button.textContent = 'Bezig…';
+
+        rows = renderSources(readSources());
+        for (const row of rows) {
+            await testSource(row.source, row.result);
+        }
+
+        button.disabled = false;
+        button.textContent = 'Test opnieuw';
+    });
+})();

--- a/templates/page-fm-player.twig
+++ b/templates/page-fm-player.twig
@@ -121,6 +121,10 @@
             </div>
         </section>
 
+        {% if show_stream_diagnostics %}
+            {{ include('partial/fm-stream-diagnostics.twig', {card: card, muted: muted}) }}
+        {% endif %}
+
         <section class="mx-auto max-w-960 px-4 pt-7" data-upcoming
                  {% if upcoming is empty %}hidden{% endif %}>
             <h2 class="mb-5 text-2xl font-bold md:text-3xl">Straks</h2>

--- a/templates/partial/fm-stream-diagnostics.twig
+++ b/templates/partial/fm-stream-diagnostics.twig
@@ -1,0 +1,60 @@
+{# Reads its sources from the rendered #zw-fm-stream element rather than its own context, so the
+   panel can never report a source list that differs from the one the player was handed. #}
+<section class="mx-auto max-w-960 px-4 pt-7" aria-labelledby="stream-diagnostics-title" data-stream-diagnostics>
+    <h2 id="stream-diagnostics-title" class="mb-5 text-2xl font-bold md:text-3xl">Wat kan deze browser?</h2>
+
+    <div class="{{ card }} p-4 sm:p-5">
+        <p class="mb-4 text-sm {{ muted }}">
+            Deze sectie is alleen zichtbaar met <code>?debug=streams</code> in de URL en is bedoeld om
+            afspeelproblemen op een specifiek toestel te herleiden.
+        </p>
+
+        <p class="mb-5 rounded-sm border-l-4 border-roze bg-roze/5 px-4 py-3 text-sm font-bold"
+           data-diagnostics-verdict>Bezig met testen…</p>
+
+        <h3 class="mb-2 font-bold">Codecondersteuning</h3>
+        <p class="mb-3 text-sm {{ muted }}">
+            Het antwoord van <code>canPlayType()</code>, precies de vraag die de speler stelt voordat hij
+            een bron kiest. Een browser die <em>maybe</em> zegt, kan alsnog stilvallen bij het decoderen.
+        </p>
+        <div class="mb-6 overflow-x-auto">
+            <table class="w-full text-left text-sm">
+                <thead>
+                    <tr class="border-b border-gray-800/10 dark:border-gray-200/10">
+                        <th scope="col" class="py-2 pr-3 font-bold">Formaat</th>
+                        <th scope="col" class="py-2 pr-3 font-bold">MIME</th>
+                        <th scope="col" class="py-2 pr-3 font-bold">canPlayType</th>
+                        <th scope="col" class="py-2 font-bold">MSE</th>
+                    </tr>
+                </thead>
+                <tbody data-diagnostics-codecs></tbody>
+            </table>
+        </div>
+
+        <h3 class="mb-2 font-bold">Ingestelde streams</h3>
+        <p class="mb-3 text-sm {{ muted }}">
+            De bronnen zoals ze in de pagina staan, in de volgorde waarin de speler ze afgaat.
+            De test speelt gedempt af, dus je hoort niets.
+        </p>
+        <div class="mb-4 overflow-x-auto">
+            <table class="w-full text-left text-sm">
+                <thead>
+                    <tr class="border-b border-gray-800/10 dark:border-gray-200/10">
+                        <th scope="col" class="py-2 pr-3 font-bold">#</th>
+                        <th scope="col" class="py-2 pr-3 font-bold">Bron</th>
+                        <th scope="col" class="py-2 pr-3 font-bold">Keuze</th>
+                        <th scope="col" class="py-2 font-bold">Resultaat</th>
+                    </tr>
+                </thead>
+                <tbody data-diagnostics-sources></tbody>
+            </table>
+        </div>
+
+        <button type="button" data-diagnostics-run
+                class="rounded-sm bg-roze px-4 py-2 font-bold text-white transition hover:bg-[#8f004e] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-roze">
+            Test de streams
+        </button>
+
+        <p class="mt-5 text-xs break-words {{ muted }}" data-diagnostics-env></p>
+    </div>
+</section>

--- a/wp-page-fm-player.php
+++ b/wp-page-fm-player.php
@@ -45,6 +45,8 @@ foreach ($streamTypes as $field => $mimeType) {
     }
 }
 
+$context['show_stream_diagnostics'] = zw_fm_stream_diagnostics_enabled();
+
 $context['media_artwork'] = [];
 $artworkUrl = $context['options']['radio_fallback_img']['url'] ?? null;
 if ($artworkUrl && $context['stream_sources']) {


### PR DESCRIPTION
## Waarom

Een Android-luisteraar meldde dat de FM live-speler geen geluid geeft. Dat is nu niet te herleiden: `fm-live.js` slikt zowel de afgewezen `play()` als het `error`-event van de speler in, zonder logging of melding. De knop springt terug naar het play-icoon en dat is alles wat er gebeurt.

De belangrijkste verdenking is de AAC-bron. Die staat vooraan en wordt aangeboden als `audio/mp4`, maar als het een Icecast AAC+/HE-AAC-stream is klopt die container-MIME niet. Een toestel dat `audio/mp4` accepteert maar HE-AAC niet kan decoderen, krijgt die bron toegewezen en valt daarna niet terug op MP3, omdat Video.js zich aan één bron vastlegt in plaats van de `<source>`-lijst af te lopen zoals een kaal media-element doet.

Deze PR lost dat nog niet op. Hij maakt het meetbaar, zodat we de aanname kunnen bevestigen voor we gedrag veranderen.

## Wat dit toevoegt

Een paneel boven "Straks", alleen zichtbaar met `?debug=streams`:

- **Codecondersteuning.** Wat `canPlayType()` antwoordt, inclusief de specifieke codecstrings (`mp4a.40.2` voor AAC-LC, `mp4a.40.5` en `mp4a.40.29` voor HE-AAC v1/v2) naast de kale `audio/mp4`-container, plus `MediaSource.isTypeSupported()`.
- **Ingestelde streams.** De bronnen zoals ze in de pagina staan, in speler-volgorde, met een markering welke bron de speler kiest en een waarschuwing bij mixed content.
- **Streamtest.** Laadt elke bron gedempt en rapporteert de uitkomst met de `MediaError`-code erbij, zodat "decoder weigert" (code 3) te onderscheiden is van "codec niet ondersteund" (code 4) en van een netwerkfout (code 2).
- **Samenvatting** die het verschil tussen de twee tabellen benoemt, en de omgevingsgegevens (userAgent, secure context, Video.js-versie) in één regel om te kopiëren.

## Keuzes

**Query parameter in plaats van een capability.** Een luisteraar met een probleem heeft geen account, en je wilt diegene gewoon een werkende link kunnen sturen. Het paneel toont niets wat een script op die pagina niet toch al kan uitlezen, en zonder de parameter wordt noch de markup noch het script uitgestuurd.

**Het paneel leest zijn bronnen uit het gerenderde `#zw-fm-stream`-element**, niet uit een eigen contextvariabele. Daarmee kan het geen lijst tonen die afwijkt van wat de speler daadwerkelijk kreeg aangeboden.

**Losstaand bestand.** `fm-stream-diagnostics.js` staat naast `fm-live.js` in plaats van erin, zodat een fout in het diagnosepad de speler niet kan omvertrekken.

## Testen

- `vendor/bin/phpcs` schoon, `composer lint:twig` schoon (57 bestanden), `node --check` op beide JS-bestanden schoon.
- Tailwind-build gecontroleerd: de kleurklassen die alleen in het JS-bestand voorkomen worden gegenereerd, `./static/**/*.js` staat in de content-globs.
- Zonder `?debug=streams` verandert er niets aan de pagina en wordt het script niet ingeladen.

## Vervolg

Twee losse dingen die hier bewust buiten blijven:

1. **De fallback zelf.** Doorschakelen naar de volgende bron bij een `MEDIA_ERR_DECODE` of `MEDIA_ERR_SRC_NOT_SUPPORTED`, en die keuze onthouden per toestel.
2. **Video.js hier weghalen.** Alle API die deze pagina gebruikt heeft een directe native tegenhanger, de speler-UI wordt niet gebruikt (`controls: false`) en het enige dat Video.js toevoegt is HLS via MSE. HLS staat laatst in de prioriteitslijst en wordt dus alleen bereikt als AAC, MP3 en OGG alledrie leeg zijn. Weghalen scheelt de bundel plus de render-blocking `video-js.min.css`, en geeft meteen de native `<source>`-fallback terug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional FM stream diagnostics panel, enabled with the `debug=streams` parameter.
  * Displays browser codec support, media environment details, configured stream sources, and test outcomes.
  * Allows users to rerun muted stream tests sequentially, with timeout and error reporting.
  * Highlights potential mixed-content issues affecting stream playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->