### PR TITLE
fix: restore FM live playback on Android

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -968,7 +968,7 @@ function zw_enqueue_theme_assets()
 
 add_action('wp_enqueue_scripts', 'zw_enqueue_theme_assets');
 
-/** Adds VideoJS as a dependency only when the controller requested a stream player. */
+/** Drives a plain <audio> element, so the player needs no dependencies of its own. */
 function zw_enqueue_fm_live_assets()
 {
     if (!is_page_template('wp-page-fm-player.php')) {
@@ -978,7 +978,7 @@ function zw_enqueue_fm_live_assets()
     wp_enqueue_script(
         'zw-fm-live',
         get_theme_file_uri('static/fm-live.js'),
-        empty($GLOBALS['zw_requires_videojs']) ? [] : ['zw-videojs-init'],
+        [],
         wp_get_theme()->get('Version'),
         ['strategy' => 'defer', 'in_footer' => true]
     );

--- a/static/fm-live.js
+++ b/static/fm-live.js
@@ -404,7 +404,7 @@
         }
     }
 
-    function setupVolume(player, volumeGroup) {
+    function setupVolume(audio, volumeGroup) {
         const volumeToggle = volumeGroup.querySelector('[data-volume-toggle]');
         const volumePanel = volumeGroup.querySelector('[data-volume-panel]');
         const volumeControl = volumeGroup.querySelector('[data-volume]');
@@ -420,7 +420,7 @@
         };
 
         const renderVolume = function () {
-            const volume = player.muted() ? 0 : player.volume();
+            const volume = audio.muted ? 0 : audio.volume;
             const percentage = Math.round(volume * 100);
             volumeControl.value = percentage;
             volumeControl.setAttribute('aria-valuetext', `${percentage}%`);
@@ -428,8 +428,8 @@
         };
 
         volumeControl.addEventListener('input', function () {
-            player.muted(false);
-            player.volume(Number(volumeControl.value) / 100);
+            audio.muted = false;
+            audio.volume = Number(volumeControl.value) / 100;
         });
         volumeToggle.addEventListener('click', function () {
             const open = volumePanel.hidden;
@@ -455,7 +455,7 @@
                 setVolumeOpen(false);
             }
         });
-        player.on('volumechange', renderVolume);
+        audio.addEventListener('volumechange', renderVolume);
         renderVolume();
     }
 
@@ -467,20 +467,13 @@
 
         const volumeGroup = document.querySelector('[data-volume-control]');
 
-        if (!streamElement || typeof videojs === 'undefined' || !window.zwVideoJsHtml5) {
+        if (!streamElement) {
             button.hidden = true;
             if (volumeGroup) {
                 volumeGroup.hidden = true;
             }
             return;
         }
-
-        const player = videojs(streamElement, {
-            controls: false,
-            liveui: true,
-            preload: 'none',
-            html5: window.zwVideoJsHtml5()
-        });
 
         const playIcon = button.querySelector('[data-play-icon="play"]');
         const pauseIcon = button.querySelector('[data-play-icon="pause"]');
@@ -497,8 +490,10 @@
 
         const startPlayback = function () {
             // Reload before playing: this is a live stream, so resuming must jump to the edge.
-            player.load();
-            player.play()?.catch(() => setPlaying(false));
+            // load() also restarts source selection, so a codec that failed last time is retried
+            // from the top rather than staying demoted for the rest of the page view.
+            streamElement.load();
+            streamElement.play()?.catch(() => setPlaying(false));
             setPlaying(true);
             updateMediaSession();
 
@@ -506,13 +501,27 @@
             resumeFeeds();
         };
 
-        player.on('playing', () => setPlaying(true));
-        player.on('pause', () => setPlaying(false));
-        player.on('error', () => setPlaying(false));
+        streamElement.addEventListener('playing', () => setPlaying(true));
+        streamElement.addEventListener('pause', () => setPlaying(false));
+        // Fires for a source that dies after it was already selected, such as a mid-stream decode
+        // failure. Running out of candidates does not reach this handler.
+        streamElement.addEventListener('error', () => setPlaying(false));
+
+        // Exhausting every <source> leaves the element in NETWORK_NO_SOURCE and fires no error on
+        // the element itself, so the button would sit on "Pauzeer" forever after a failed start.
+        // Each rejected candidate fires its own error, which capture picks up on the way down, and
+        // the network state settles one task later.
+        streamElement.addEventListener('error', function () {
+            setTimeout(function () {
+                if (streamElement.networkState === HTMLMediaElement.NETWORK_NO_SOURCE) {
+                    setPlaying(false);
+                }
+            });
+        }, true);
 
         button.addEventListener('click', function () {
-            if (!player.paused()) {
-                player.pause();
+            if (!streamElement.paused) {
+                streamElement.pause();
                 return;
             }
 
@@ -521,9 +530,9 @@
 
         if ('mediaSession' in navigator) {
             navigator.mediaSession.setActionHandler('play', startPlayback);
-            navigator.mediaSession.setActionHandler('pause', () => player.pause());
+            navigator.mediaSession.setActionHandler('pause', () => streamElement.pause());
             try {
-                navigator.mediaSession.setActionHandler('stop', () => player.pause());
+                navigator.mediaSession.setActionHandler('stop', () => streamElement.pause());
             } catch (error) {
                 // Some browsers expose Media Session without the `stop` action.
             }
@@ -531,7 +540,7 @@
 
         // Last: playback is the primary control, so it gets wired before the secondary one.
         if (volumeGroup) {
-            setupVolume(player, volumeGroup);
+            setupVolume(streamElement, volumeGroup);
         }
     }
 

--- a/static/fm-live.js
+++ b/static/fm-live.js
@@ -445,8 +445,10 @@
             }
         });
         // Escape only reaches this group while focus is inside it, so tabbing away must dismiss too.
+        // Native range controls can report no related target during pointer interaction; the
+        // document click handler below still closes the panel for an actual outside click.
         volumeGroup.addEventListener('focusout', function (event) {
-            if (!volumeGroup.contains(event.relatedTarget)) {
+            if (event.relatedTarget && !volumeGroup.contains(event.relatedTarget)) {
                 setVolumeOpen(false);
             }
         });

--- a/static/videojs-init.js
+++ b/static/videojs-init.js
@@ -4,7 +4,6 @@
  * Chrome has issues with native HLS playback. This script configures VideoJS
  * to use VHS (Video.js HTTP Streaming) with the correct settings.
  */
-// fm-live.js uses the same HTML5 options for its page-scoped player.
 window.zwVideoJsHtml5 = function () {
     return {
         vhs: {

--- a/templates/page-fm-player.twig
+++ b/templates/page-fm-player.twig
@@ -71,9 +71,9 @@
         {% if has_stream %}
             {# Without `controls` the element renders nothing; the visible button drives it. Keeping
                the streams as <source> children leaves codec fallback to the browser, which walks
-               them in order and moves on when one will not load. A single JS-assigned src cannot:
-               a device that accepts the audio/mp4 container but has no HE-AAC decoder would be
-               stuck on the AAC stream instead of dropping through to MP3. #}
+               them in order and moves on when one will not load. A single JS-assigned src cannot,
+               which is why a device that chokes on the AAC mount used to sit in silence rather
+               than dropping through to the MP3 behind it. #}
             <audio id="zw-fm-stream" preload="none">
                 {% for source in stream_sources %}
                     <source src="{{ function('esc_url', source.url) }}" type="{{ source.type }}">

--- a/templates/page-fm-player.twig
+++ b/templates/page-fm-player.twig
@@ -69,14 +69,16 @@
         </header>
 
         {% if has_stream %}
-            {# VideoJS owns this hidden media element; the visible button is its control. #}
-            <div class="hidden" aria-hidden="true">
-                <audio id="zw-fm-stream" class="video-js" preload="none" playsinline>
-                    {% for source in stream_sources %}
-                        <source src="{{ function('esc_url', source.url) }}" type="{{ source.type }}">
-                    {% endfor %}
-                </audio>
-            </div>
+            {# Without `controls` the element renders nothing; the visible button drives it. Keeping
+               the streams as <source> children leaves codec fallback to the browser, which walks
+               them in order and moves on when one will not load. A single JS-assigned src cannot:
+               a device that accepts the audio/mp4 container but has no HE-AAC decoder would be
+               stuck on the AAC stream instead of dropping through to MP3. #}
+            <audio id="zw-fm-stream" preload="none">
+                {% for source in stream_sources %}
+                    <source src="{{ function('esc_url', source.url) }}" type="{{ source.type }}">
+                {% endfor %}
+            </audio>
         {% endif %}
 
         <section class="mx-auto max-w-960 px-4 pt-7" aria-labelledby="live-player-title">

--- a/wp-page-fm-player.php
+++ b/wp-page-fm-player.php
@@ -29,9 +29,13 @@ if ($current?->show) {
 
 $context['upcoming'] = array_map(fn ($broadcast) => $broadcast->toArray(), $schedule->getUpcomingRadioBroadcasts(2));
 
-// VideoJS tries sources in insertion order.
+// The browser walks these in order and moves to the next candidate when one will not load, so
+// each stream has to be announced with the type the server actually sends. Icecast serves the AAC
+// mount as raw ADTS (Content-Type: audio/aac); calling that audio/mp4 makes a browser accept bytes
+// it then hands to an MP4 demuxer, which strands devices that are strict about it on a dead source
+// instead of letting them fall through to MP3.
 $streamTypes = [
-    'radio_webplayer_aac_stream' => 'audio/mp4',
+    'radio_webplayer_aac_stream' => 'audio/aac',
     'radio_webplayer_mp3_stream' => 'audio/mpeg',
     'radio_webplayer_ogg_stream' => 'audio/ogg',
     'radio_webplayer_hls_stream' => 'application/x-mpegURL',

--- a/wp-page-fm-player.php
+++ b/wp-page-fm-player.php
@@ -87,9 +87,4 @@ foreach (zw_acf_rows($context['options']['radio_frequenties'] ?? null) as $row) 
 
 $context['frequency_groups'] = array_values(array_filter($groups, fn ($group) => $group['channels']));
 
-// Avoid loading VideoJS when the page has no stream.
-if ($context['stream_sources']) {
-    zw_require_videojs();
-}
-
 Timber::render(['page-fm-player.twig', 'page.twig'], $context);


### PR DESCRIPTION
## Summary

Fixes FM live playback on Android and other strict browsers by:

- Declaring the raw Icecast AAC stream as `audio/aac` instead of `audio/mp4`.
- Replacing Video.js on the FM page with a native `<audio>` element, allowing browsers to fall back to MP3 when a source is unsupported.
- Resetting the play button when all sources fail.

This also removes the Video.js bundle and render-blocking stylesheet from this page.

## Testing

- Verified playback on the Android device affected by the issue.
- Verified fallback from a broken first source to a working second source.
- Verified volume controls and the all-sources-failed state.
- `node --check static/fm-live.js`
- `vendor/bin/phpcs`
- `composer lint:twig`

## HLS note

Removing Video.js also removes its cross-browser HLS implementation. Native HLS support varies by browser, platform, and stream. Production is unaffected while AAC or MP3 is available. If HLS becomes the only source, cross-browser playback should be verified and hls.js may be needed where native playback is unavailable or unreliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the live FM player to use native browser audio controls for volume, playback, and Media Session actions.
  - Improved playback recovery when a stream source fails.
  - Removed the unnecessary Video.js wrapper and dependency for a simpler, more reliable player.
  - Corrected AAC stream handling to use the appropriate audio format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->