### PR TITLE
feat: add email links for FM presenters

### DIFF
--- a/streekomroep-acf-json/group_5f21b1dcb2dc2.json
+++ b/streekomroep-acf-json/group_5f21b1dcb2dc2.json
@@ -109,6 +109,26 @@
                     "mime_types": "",
                     "preview_size": "thumbnail",
                     "parent_repeater": "field_687a3f5e0c1a1"
+                },
+                {
+                    "key": "field_68985c0e0f5a5",
+                    "label": "E-mailadres",
+                    "name": "fm_show_maker_email",
+                    "aria-label": "",
+                    "type": "email",
+                    "instructions": "Wordt als e-maillink onder deze maker op de programmapagina getoond.",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "parent_repeater": "field_687a3f5e0c1a1"
                 }
             ],
             "rows_per_page": 20
@@ -277,5 +297,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1784232505
+    "modified": 1786280427
 }

--- a/templates/page-colofon.twig
+++ b/templates/page-colofon.twig
@@ -2,6 +2,7 @@
 
 {% block content %}
     {% import 'partial/badge.twig' as badge %}
+    {% import 'partial/mail-link.twig' as mail_link %}
     {% import 'partial/responsive-image.twig' as responsive %}
     <article class="post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
         <div class="mx-auto w-full max-w-960 px-4 py-7 lg:py-9">
@@ -55,13 +56,7 @@
                                         {{ person.name }}
                                     {% endif %}
                                 </h2>
-                                {% if person.email %}
-                                    <a href="mailto:{{ person.email }}" title="Mail {{ person.name }} ({{ person.email }})"
-                                       class="mt-1.5 inline-flex items-center gap-1.5 text-sm font-semibold text-gray-500 transition hover:text-gray-900 dark:text-gray-400 dark:hover:text-white [&>svg]:h-4 [&>svg]:w-4">
-                                        {{ icon('icon-mail') }}
-                                        Mail
-                                    </a>
-                                {% endif %}
+                                {{ mail_link.render(person.email, person.name) }}
                             </article>
                         {% endfor %}
                     </div>

--- a/templates/partial/mail-link.twig
+++ b/templates/partial/mail-link.twig
@@ -1,6 +1,7 @@
 {% macro render(email, name) %}
     {%- if email -%}
         <a href="mailto:{{ email|e('html_attr') }}"
+           aria-label="Mail {{ name|e('html_attr') }}"
            title="Mail {{ name|e('html_attr') }} ({{ email|e('html_attr') }})"
            class="mt-1.5 inline-flex items-center gap-1.5 text-sm font-semibold text-gray-500 transition hover:text-gray-900 dark:text-gray-400 dark:hover:text-white [&>svg]:size-4">
             {{ icon('icon-mail') }}

--- a/templates/partial/mail-link.twig
+++ b/templates/partial/mail-link.twig
@@ -1,0 +1,10 @@
+{% macro render(email, name) %}
+    {%- if email -%}
+        <a href="mailto:{{ email|e('html_attr') }}"
+           title="Mail {{ name|e('html_attr') }} ({{ email|e('html_attr') }})"
+           class="mt-1.5 inline-flex items-center gap-1.5 text-sm font-semibold text-gray-500 transition hover:text-gray-900 dark:text-gray-400 dark:hover:text-white [&>svg]:size-4">
+            {{ icon('icon-mail') }}
+            Mail
+        </a>
+    {%- endif -%}
+{% endmacro %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -59,6 +59,14 @@
                                         {% if maker.fm_show_maker_bio %}
                                             <p class="mt-1 text-sm leading-snug text-gray-500 dark:text-gray-400">{{ maker.fm_show_maker_bio }}</p>
                                         {% endif %}
+                                        {% if maker.fm_show_maker_email %}
+                                            <a href="mailto:{{ maker.fm_show_maker_email }}"
+                                               title="Mail {{ maker.fm_show_maker_naam }} ({{ maker.fm_show_maker_email }})"
+                                               class="mt-1.5 inline-flex items-center gap-1.5 text-sm font-semibold text-gray-500 transition hover:text-gray-900 dark:text-gray-400 dark:hover:text-white [&>svg]:h-4 [&>svg]:w-4">
+                                                {{ icon('icon-mail') }}
+                                                Mail
+                                            </a>
+                                        {% endif %}
                                     </div>
                                 </div>
                             {% endfor %}

--- a/templates/single-fm.twig
+++ b/templates/single-fm.twig
@@ -2,6 +2,7 @@
 
 {% block content %}
     {% import 'partial/badge.twig' as badge %}
+    {% import 'partial/mail-link.twig' as mail_link %}
     {% set makers = post.meta('fm_show_makers')|rows %}
     {% set card = 'rounded-sm border border-gray-800/10 bg-gray-50 p-4 dark:border-gray-200/10 dark:bg-gray-700/40' %}
     {% set card_title = 'mb-3 font-round text-sm font-bold tracking-wide text-gray-400 uppercase' %}
@@ -59,14 +60,7 @@
                                         {% if maker.fm_show_maker_bio %}
                                             <p class="mt-1 text-sm leading-snug text-gray-500 dark:text-gray-400">{{ maker.fm_show_maker_bio }}</p>
                                         {% endif %}
-                                        {% if maker.fm_show_maker_email %}
-                                            <a href="mailto:{{ maker.fm_show_maker_email }}"
-                                               title="Mail {{ maker.fm_show_maker_naam }} ({{ maker.fm_show_maker_email }})"
-                                               class="mt-1.5 inline-flex items-center gap-1.5 text-sm font-semibold text-gray-500 transition hover:text-gray-900 dark:text-gray-400 dark:hover:text-white [&>svg]:h-4 [&>svg]:w-4">
-                                                {{ icon('icon-mail') }}
-                                                Mail
-                                            </a>
-                                        {% endif %}
+                                        {{ mail_link.render(maker.fm_show_maker_email, maker.fm_show_maker_naam) }}
                                     </div>
                                 </div>
                             {% endfor %}


### PR DESCRIPTION
## Summary

- adds an optional ACF email field for each FM presenter
- displays the same compact `Mail` link used on the colophon page
- hides the link when no email address is configured

## WordPress/ACF

This PR includes the updated local ACF JSON export. After deployment, synchronize the field group if prompted by ACF.

## Testing

- `composer lint:twig`
- `vendor/bin/phpcs --standard=phpcs.xml .`
- validated the ACF JSON with `jq`
- confirmed the local FM program page returns HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Program makers can now optionally include an email address.
  - Added email validation to help ensure contact details are entered correctly.
  - Program pages display an email contact link with a mail icon and “Mail” label when an address is provided.
  - Contact links now use consistent styling, accessible labels, and tooltips across program and colophon pages.
  - Email links are hidden when no address is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->